### PR TITLE
Utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ fixed_point_test
 # CLion
 .idea/workspace.xml
 .idea/dictionaries
+
+# Visual Studio
+vs/.vs
+vs/Debug
+vs/Release
+vs/fixed_point_test.opensdf
+vs/fixed_point_test.sdf

--- a/.idea/fixed_point.iml
+++ b/.idea/fixed_point.iml
@@ -4,7 +4,9 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/CMakeLists.txt" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/fixed_point_test.cpp" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/fixed_point_utils_test.cpp" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main.cpp" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/proposal_test.cpp" isTestSource="false" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,9 @@ set(SG14_TEST_SOURCE_DIRECTORY "src")
 
 set(SOURCE_FILES
     ${SG14_TEST_SOURCE_DIRECTORY}/main.cpp
-    ${SG14_TEST_SOURCE_DIRECTORY}/fixed_point_test.cpp)
+    ${SG14_TEST_SOURCE_DIRECTORY}/fixed_point_test.cpp 
+    ${SG14_TEST_SOURCE_DIRECTORY}/fixed_point_utils_test.cpp
+    ${SG14_TEST_SOURCE_DIRECTORY}/proposal_test.cpp)
 
 add_executable(fixed_point_test ${SOURCE_FILES})
 

--- a/include/fixed_point.h
+++ b/include/fixed_point.h
@@ -278,15 +278,6 @@ namespace sg14
 		}
 
 		////////////////////////////////////////////////////////////////////////////////
-		// sg14::_impl::default_exponent
-
-		template <class ReprType>
-		constexpr int default_exponent() noexcept
-		{
-			return num_bits<ReprType>() / -2;
-		}
-
-		////////////////////////////////////////////////////////////////////////////////
 		// sg14::_impl::pow2
 
 		// returns given power of 2
@@ -395,7 +386,7 @@ namespace sg14
 	// approximates a real number using a built-in integral type;
 	// somewhat like a floating-point number but with exponent determined at run-time
 
-	template <class ReprType = int, int Exponent = _impl::default_exponent<ReprType>()>
+	template <class ReprType = int, int Exponent = 0>
 	class fixed_point
 	{
 	public:

--- a/include/fixed_point.h
+++ b/include/fixed_point.h
@@ -1,14 +1,9 @@
 #if ! defined(_SG14_FIXED_POINT)
 #define _SG14_FIXED_POINT 1
 
-#include <algorithm>
 #include <climits>
-#include <cmath>
 #include <cinttypes>
-#include <limits>
 #include <type_traits>
-#include <ostream>
-#include <istream>
 
 #if defined(__clang__) || defined(__GNUG__)
 // sg14::float_point only fully supports 64-bit types with the help of 128-bit ints.
@@ -596,20 +591,6 @@ namespace sg14
 	};
 
 	////////////////////////////////////////////////////////////////////////////////
-	// sg14::is_fixed_point
-
-	template <class T>
-	struct is_fixed_point;
-
-	template <class T>
-	struct is_fixed_point
-		: public std::integral_constant<bool, false> {};
-
-	template <class ReprType, int Exponent>
-	struct is_fixed_point <fixed_point<ReprType, Exponent>>
-		: public std::integral_constant<bool, true> {};
-
-	////////////////////////////////////////////////////////////////////////////////
 	// sg14::make_fixed
 
 	// given the desired number of integer and fractional digits,
@@ -748,16 +729,6 @@ namespace sg14
 	}
 
 	////////////////////////////////////////////////////////////////////////////////
-	// sg14::abs
-
-	template <class ReprType, int Exponent, typename std::enable_if<_impl::is_signed<ReprType>::value, int>::type Dummy = 0>
-	constexpr fixed_point<ReprType, Exponent>
-	abs(const fixed_point<ReprType, Exponent> & x) noexcept
-	{
-		return (x.data() >= 0) ? x : - x;
-	}
-
-	////////////////////////////////////////////////////////////////////////////////
 	// sg14::sqrt
 
 	// https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Binary_numeral_system_.28base_2.29
@@ -768,38 +739,6 @@ namespace sg14
 	{
 		return fixed_point<ReprType, Exponent>::from_data(
 			static_cast<ReprType>(_impl::sqrt_solve1(promote(x).data())));
-	}
-
-	////////////////////////////////////////////////////////////////////////////////
-	// sg14::trig
-	//
-	// Placeholder implementations fall back on <cmath> functions which is slow
-	// due to conversion to and from floating-point types; also inconvenient as
-	// many <cmath> functions are not constexpr.
-
-	namespace _impl
-	{
-		template <class ReprType, int Exponent, _impl::get_float_t<sizeof(ReprType)>(*F)(_impl::get_float_t<sizeof(ReprType)>)>
-		constexpr fixed_point<ReprType, Exponent>
-			crib(const fixed_point<ReprType, Exponent> & x) noexcept
-		{
-			using floating_point = _impl::get_float_t<sizeof(ReprType)>;
-			return static_cast<fixed_point<ReprType, Exponent>>(F(static_cast<floating_point>(x)));
-		}
-	}
-
-	template <class ReprType, int Exponent>
-	constexpr fixed_point<ReprType, Exponent>
-		sin(const fixed_point<ReprType, Exponent> & x) noexcept
-	{
-		return _impl::crib<ReprType, Exponent, std::sin>(x);
-	}
-
-	template <class ReprType, int Exponent>
-	constexpr fixed_point<ReprType, Exponent>
-		cos(const fixed_point<ReprType, Exponent> & x) noexcept
-	{
-		return _impl::crib<ReprType, Exponent, std::cos>(x);
 	}
 
 	////////////////////////////////////////////////////////////////////////////////
@@ -975,24 +914,6 @@ namespace sg14
 		return output_type::from_data(
 			_impl::shift_left<(FixedPoint::exponent * 2 - output_type::exponent), output_repr_type>(
 				static_cast<output_repr_type>(root.data()) * static_cast<output_repr_type>(root.data())));
-	}
-
-	////////////////////////////////////////////////////////////////////////////////
-	// sg14::fixed_point streaming - (placeholder implementation)
-
-	template <class ReprType, int Exponent>
-	::std::ostream & operator << (::std::ostream & out, const fixed_point<ReprType, Exponent> & fp)
-	{
-		return out << static_cast<long double>(fp);
-	}
-
-	template <class ReprType, int Exponent>
-	::std::istream & operator >> (::std::istream & in, fixed_point<ReprType, Exponent> & fp)
-	{
-		long double ld;
-		in >> ld;
-		fp = ld;
-		return in;
 	}
 
 	////////////////////////////////////////////////////////////////////////////////

--- a/include/fixed_point.h
+++ b/include/fixed_point.h
@@ -499,34 +499,6 @@ namespace sg14
 			return fixed_point(repr, 0);
 		}
 
-		// comparison
-		friend constexpr bool operator==(const fixed_point & lhs, const fixed_point & rhs) noexcept
-		{
-			return lhs._repr == rhs._repr;
-		}
-		friend constexpr bool operator!=(const fixed_point & lhs, const fixed_point & rhs) noexcept
-		{
-			return ! (lhs == rhs);
-		}
-
-		friend constexpr bool operator>(const fixed_point & lhs, const fixed_point & rhs) noexcept
-		{
-			return lhs._repr > rhs._repr;
-		}
-		friend constexpr bool operator<(const fixed_point & lhs, const fixed_point & rhs) noexcept
-		{
-			return lhs._repr < rhs._repr;
-		}
-
-		friend constexpr bool operator>=(const fixed_point & lhs, const fixed_point & rhs) noexcept
-		{
-			return lhs._repr >= rhs._repr;
-		}
-		friend constexpr bool operator<=(const fixed_point & lhs, const fixed_point & rhs) noexcept
-		{
-			return lhs._repr <= rhs._repr;
-		}
-
 	private:
 		template <class S, typename std::enable_if<std::is_floating_point<S>::value, int>::type Dummy = 0>
 		static constexpr S one() noexcept
@@ -673,58 +645,46 @@ namespace sg14
 	//
 	// compare two objects of different fixed_point specializations
 
-	template <class LhsReprType, int LhsExponent, class RhsReprType, int RhsExponent>
-	constexpr bool operator ==(
-		const fixed_point<LhsReprType, LhsExponent> & lhs,
-		const fixed_point<RhsReprType, RhsExponent> & rhs) noexcept
+	template <class Lhs, class Rhs>
+	constexpr bool operator==(const Lhs & lhs, const Rhs & rhs) noexcept
 	{
-		using fixed_point = common_type<fixed_point<LhsReprType, LhsExponent>, fixed_point<RhsReprType, RhsExponent>>;
-		return static_cast<fixed_point>(lhs) == static_cast<fixed_point>(rhs);
+		using common_type = common_type<Lhs, Rhs>;
+		return static_cast<common_type>(lhs).data() == static_cast<common_type>(rhs).data();
 	}
 
-	template <class LhsReprType, int LhsExponent, class RhsReprType, int RhsExponent>
-	constexpr bool operator !=(
-		const fixed_point<LhsReprType, LhsExponent> & lhs,
-		const fixed_point<RhsReprType, RhsExponent> & rhs) noexcept
+	template <class Lhs, class Rhs>
+	constexpr bool operator!=(const Lhs & lhs, const Rhs & rhs) noexcept
 	{
-		using fixed_point = common_type<fixed_point<LhsReprType, LhsExponent>, fixed_point<RhsReprType, RhsExponent>>;
-		return static_cast<fixed_point>(lhs) != static_cast<fixed_point>(rhs);
+		using common_type = common_type<Lhs, Rhs>;
+		return static_cast<common_type>(lhs).data() != static_cast<common_type>(rhs).data();
 	}
 
-	template <class LhsReprType, int LhsExponent, class RhsReprType, int RhsExponent>
-	constexpr bool operator <(
-		const fixed_point<LhsReprType, LhsExponent> & lhs,
-		const fixed_point<RhsReprType, RhsExponent> & rhs) noexcept
+	template <class Lhs, class Rhs>
+	constexpr bool operator<(const Lhs & lhs, const Rhs & rhs) noexcept
 	{
-		using fixed_point = common_type<fixed_point<LhsReprType, LhsExponent>, fixed_point<RhsReprType, RhsExponent>>;
-		return static_cast<fixed_point>(lhs) < static_cast<fixed_point>(rhs);
+		using common_type = common_type<Lhs, Rhs>;
+		return static_cast<common_type>(lhs).data() < static_cast<common_type>(rhs).data();
 	}
 
-	template <class LhsReprType, int LhsExponent, class RhsReprType, int RhsExponent>
-	constexpr bool operator >(
-		const fixed_point<LhsReprType, LhsExponent> & lhs,
-		const fixed_point<RhsReprType, RhsExponent> & rhs) noexcept
+	template <class Lhs, class Rhs>
+	constexpr bool operator>(const Lhs & lhs, const Rhs & rhs) noexcept
 	{
-		using fixed_point = common_type<fixed_point<LhsReprType, LhsExponent>, fixed_point<RhsReprType, RhsExponent>>;
-		return static_cast<fixed_point>(lhs) > static_cast<fixed_point>(rhs);
+		using common_type = common_type<Lhs, Rhs>;
+		return static_cast<common_type>(lhs).data() > static_cast<common_type>(rhs).data();
 	}
 
-	template <class LhsReprType, int LhsExponent, class RhsReprType, int RhsExponent>
-	constexpr bool operator >=(
-		const fixed_point<LhsReprType, LhsExponent> & lhs,
-		const fixed_point<RhsReprType, RhsExponent> & rhs) noexcept
+	template <class Lhs, class Rhs>
+	constexpr bool operator>=(const Lhs & lhs, const Rhs & rhs) noexcept
 	{
-		using fixed_point = common_type<fixed_point<LhsReprType, LhsExponent>, fixed_point<RhsReprType, RhsExponent>>;
-		return static_cast<fixed_point>(lhs) >= static_cast<fixed_point>(rhs);
+		using common_type = common_type<Lhs, Rhs>;
+		return static_cast<common_type>(lhs).data() >= static_cast<common_type>(rhs).data();
 	}
 
-	template <class LhsReprType, int LhsExponent, class RhsReprType, int RhsExponent>
-	constexpr bool operator <=(
-		const fixed_point<LhsReprType, LhsExponent> & lhs,
-		const fixed_point<RhsReprType, RhsExponent> & rhs) noexcept
+	template <class Lhs, class Rhs>
+	constexpr bool operator<=(const Lhs & lhs, const Rhs & rhs) noexcept
 	{
-		using fixed_point = common_type<fixed_point<LhsReprType, LhsExponent>, fixed_point<RhsReprType, RhsExponent>>;
-		return static_cast<fixed_point>(lhs) <= static_cast<fixed_point>(rhs);
+		using common_type = common_type<Lhs, Rhs>;
+		return static_cast<common_type>(lhs).data() <= static_cast<common_type>(rhs).data();
 	}
 
 	////////////////////////////////////////////////////////////////////////////////

--- a/include/fixed_point.h
+++ b/include/fixed_point.h
@@ -562,6 +562,20 @@ namespace sg14
 	};
 
 	////////////////////////////////////////////////////////////////////////////////
+	// sg14::is_fixed_point
+
+	template <class T>
+	struct is_fixed_point;
+
+	template <class T>
+	struct is_fixed_point
+		: public std::integral_constant<bool, false> {};
+
+	template <class ReprType, int Exponent>
+	struct is_fixed_point <fixed_point<ReprType, Exponent>>
+		: public std::integral_constant<bool, true> {};
+
+	////////////////////////////////////////////////////////////////////////////////
 	// sg14::make_fixed
 
 	// given the desired number of integer and fractional digits,

--- a/include/fixed_point.h
+++ b/include/fixed_point.h
@@ -659,42 +659,42 @@ namespace sg14
 	//
 	// compare two objects of different fixed_point specializations
 
-	template <class Lhs, class Rhs>
+	template <class Lhs, class Rhs, typename std::enable_if<is_fixed_point<Lhs>::value || is_fixed_point<Rhs>::value, int>::type Dummy = 0>
 	constexpr bool operator==(const Lhs & lhs, const Rhs & rhs) noexcept
 	{
 		using common_type = common_type<Lhs, Rhs>;
 		return static_cast<common_type>(lhs).data() == static_cast<common_type>(rhs).data();
 	}
 
-	template <class Lhs, class Rhs>
+	template <class Lhs, class Rhs, typename std::enable_if<is_fixed_point<Lhs>::value || is_fixed_point<Rhs>::value, int>::type Dummy = 0>
 	constexpr bool operator!=(const Lhs & lhs, const Rhs & rhs) noexcept
 	{
 		using common_type = common_type<Lhs, Rhs>;
 		return static_cast<common_type>(lhs).data() != static_cast<common_type>(rhs).data();
 	}
 
-	template <class Lhs, class Rhs>
+	template <class Lhs, class Rhs, typename std::enable_if<is_fixed_point<Lhs>::value || is_fixed_point<Rhs>::value, int>::type Dummy = 0>
 	constexpr bool operator<(const Lhs & lhs, const Rhs & rhs) noexcept
 	{
 		using common_type = common_type<Lhs, Rhs>;
 		return static_cast<common_type>(lhs).data() < static_cast<common_type>(rhs).data();
 	}
 
-	template <class Lhs, class Rhs>
+	template <class Lhs, class Rhs, typename std::enable_if<is_fixed_point<Lhs>::value || is_fixed_point<Rhs>::value, int>::type Dummy = 0>
 	constexpr bool operator>(const Lhs & lhs, const Rhs & rhs) noexcept
 	{
 		using common_type = common_type<Lhs, Rhs>;
 		return static_cast<common_type>(lhs).data() > static_cast<common_type>(rhs).data();
 	}
 
-	template <class Lhs, class Rhs>
+	template <class Lhs, class Rhs, typename std::enable_if<is_fixed_point<Lhs>::value || is_fixed_point<Rhs>::value, int>::type Dummy = 0>
 	constexpr bool operator>=(const Lhs & lhs, const Rhs & rhs) noexcept
 	{
 		using common_type = common_type<Lhs, Rhs>;
 		return static_cast<common_type>(lhs).data() >= static_cast<common_type>(rhs).data();
 	}
 
-	template <class Lhs, class Rhs>
+	template <class Lhs, class Rhs, typename std::enable_if<is_fixed_point<Lhs>::value || is_fixed_point<Rhs>::value, int>::type Dummy = 0>
 	constexpr bool operator<=(const Lhs & lhs, const Rhs & rhs) noexcept
 	{
 		using common_type = common_type<Lhs, Rhs>;

--- a/include/fixed_point.h
+++ b/include/fixed_point.h
@@ -494,7 +494,6 @@ namespace sg14
 		}
 
 		// creates an instance given the underlying representation value
-		// TODO: constexpr with c++14?
 		static constexpr fixed_point from_data(repr_type repr) noexcept
 		{
 			return fixed_point(repr, 0);

--- a/include/fixed_point_utils.h
+++ b/include/fixed_point_utils.h
@@ -10,20 +10,6 @@
 namespace sg14
 {
 	////////////////////////////////////////////////////////////////////////////////
-	// sg14::is_fixed_point
-
-	template <class T>
-	struct is_fixed_point;
-
-	template <class T>
-	struct is_fixed_point
-		: public std::integral_constant<bool, false> {};
-
-	template <class ReprType, int Exponent>
-	struct is_fixed_point <fixed_point<ReprType, Exponent>>
-		: public std::integral_constant<bool, true> {};
-
-	////////////////////////////////////////////////////////////////////////////////
 	// sg14::abs
 
 	template <class ReprType, int Exponent, typename std::enable_if<_impl::is_signed<ReprType>::value, int>::type Dummy = 0>

--- a/include/fixed_point_utils.h
+++ b/include/fixed_point_utils.h
@@ -1,0 +1,87 @@
+#if ! defined(_SG14_FIXED_POINT_UTILS_H)
+#define _SG14_FIXED_POINT_UTILS_H 1
+
+#include "fixed_point.h"
+
+#include <cmath>
+#include <istream>
+#include <ostream>
+
+namespace sg14
+{
+	////////////////////////////////////////////////////////////////////////////////
+	// sg14::is_fixed_point
+
+	template <class T>
+	struct is_fixed_point;
+
+	template <class T>
+	struct is_fixed_point
+		: public std::integral_constant<bool, false> {};
+
+	template <class ReprType, int Exponent>
+	struct is_fixed_point <fixed_point<ReprType, Exponent>>
+		: public std::integral_constant<bool, true> {};
+
+	////////////////////////////////////////////////////////////////////////////////
+	// sg14::abs
+
+	template <class ReprType, int Exponent, typename std::enable_if<_impl::is_signed<ReprType>::value, int>::type Dummy = 0>
+	constexpr fixed_point<ReprType, Exponent>
+	abs(const fixed_point<ReprType, Exponent> & x) noexcept
+	{
+		return (x.data() >= 0) ? x : - x;
+	}
+
+	////////////////////////////////////////////////////////////////////////////////
+	// sg14::trig
+	//
+	// Placeholder implementations fall back on <cmath> functions which is slow
+	// due to conversion to and from floating-point types; also inconvenient as
+	// many <cmath> functions are not constexpr.
+
+	namespace _impl
+	{
+		template <class ReprType, int Exponent, _impl::get_float_t<sizeof(ReprType)>(*F)(_impl::get_float_t<sizeof(ReprType)>)>
+		constexpr fixed_point<ReprType, Exponent>
+		crib(const fixed_point<ReprType, Exponent> & x) noexcept
+		{
+			using floating_point = _impl::get_float_t<sizeof(ReprType)>;
+			return static_cast<fixed_point<ReprType, Exponent>>(F(static_cast<floating_point>(x)));
+		}
+	}
+
+	template <class ReprType, int Exponent>
+	constexpr fixed_point<ReprType, Exponent>
+	sin(const fixed_point<ReprType, Exponent> & x) noexcept
+	{
+		return _impl::crib<ReprType, Exponent, std::sin>(x);
+	}
+
+	template <class ReprType, int Exponent>
+	constexpr fixed_point<ReprType, Exponent>
+	cos(const fixed_point<ReprType, Exponent> & x) noexcept
+	{
+		return _impl::crib<ReprType, Exponent, std::cos>(x);
+	}
+
+	////////////////////////////////////////////////////////////////////////////////
+	// sg14::fixed_point streaming - (placeholder implementation)
+
+	template <class ReprType, int Exponent>
+	::std::ostream & operator << (::std::ostream & out, const fixed_point<ReprType, Exponent> & fp)
+	{
+		return out << static_cast<long double>(fp);
+	}
+
+	template <class ReprType, int Exponent>
+	::std::istream & operator >> (::std::istream & in, fixed_point<ReprType, Exponent> & fp)
+	{
+		long double ld;
+		in >> ld;
+		fp = ld;
+		return in;
+	}
+}
+
+#endif	// defined(_SG14_FIXED_POINT_UTILS_H)

--- a/src/fixed_point_test.cpp
+++ b/src/fixed_point_test.cpp
@@ -12,7 +12,7 @@ void fixed_point_test()
 	// copy assignment
 
 	// from fixed_point
-	auto rhs = fixed_point<>(123.456);
+	auto rhs = fixed_point<uint32_t, -16>(123.456);
 	auto lhs = rhs;
 	ASSERT_EQUAL(lhs, fixed_point<>(123.456));
 
@@ -147,19 +147,19 @@ static_assert(std::is_same<_impl::necessary_repr_t<128, true>, __int128>::value,
 ////////////////////////////////////////////////////////////////////////////////
 // default second template parameter
 
-static_assert(std::is_same<fixed_point<std::int8_t>, fixed_point<std::int8_t, -4>>::value, "sg14::fixed_point test failed");
-static_assert(std::is_same<fixed_point<std::uint8_t>, fixed_point<std::uint8_t, -4>>::value, "sg14::fixed_point test failed");
-static_assert(std::is_same<fixed_point<std::int16_t>, fixed_point<std::int16_t, -8>>::value, "sg14::fixed_point test failed");
-static_assert(std::is_same<fixed_point<std::uint16_t>, fixed_point<std::uint16_t, -8>>::value, "sg14::fixed_point test failed");
-static_assert(std::is_same<fixed_point<std::int32_t>, fixed_point<std::int32_t, -16>>::value, "sg14::fixed_point test failed");
-static_assert(std::is_same<fixed_point<std::uint32_t>, fixed_point<std::uint32_t, -16>>::value, "sg14::fixed_point test failed");
-static_assert(std::is_same<fixed_point<std::int64_t>, fixed_point<std::int64_t, -32>>::value, "sg14::fixed_point test failed");
-static_assert(std::is_same<fixed_point<std::uint64_t>, fixed_point<std::uint64_t, -32>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<std::int8_t>, fixed_point<std::int8_t, 0>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<std::uint8_t>, fixed_point<std::uint8_t, 0>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<std::int16_t>, fixed_point<std::int16_t, 0>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<std::uint16_t>, fixed_point<std::uint16_t, 0>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<std::int32_t>, fixed_point<std::int32_t, 0>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<std::uint32_t>, fixed_point<std::uint32_t, 0>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<std::int64_t>, fixed_point<std::int64_t, 0>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<std::uint64_t>, fixed_point<std::uint64_t, 0>>::value, "sg14::fixed_point test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // default first template parameter
 
-static_assert(std::is_same<fixed_point<int, _impl::num_bits<int>() / -2>, fixed_point<>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<int, 0>, fixed_point<>>::value, "sg14::fixed_point test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // conversion
@@ -307,15 +307,15 @@ static_assert(!(fixed_point<uint8_t>(4.5) != fixed_point<int16_t>(4.5)), "sg14::
 static_assert(fixed_point<uint8_t>(4.5) < fixed_point<int16_t>(5.6), "sg14::fixed_point test failed");
 static_assert(!(fixed_point<int8_t>(-4.5) < fixed_point<int16_t>(-5.6)), "sg14::fixed_point test failed");
 
-static_assert(fixed_point<uint8_t>(4.6) > fixed_point<int16_t>(4.5), "sg14::fixed_point test failed");
-static_assert(!(fixed_point<uint8_t>(4.6) < fixed_point<int16_t>(-4.5)), "sg14::fixed_point test failed");
+static_assert(fixed_point<uint8_t, -4>(4.6) > fixed_point<int16_t, -8>(4.5), "sg14::fixed_point test failed");
+static_assert(!(fixed_point<uint8_t, -4>(4.6) < fixed_point<int16_t, -8>(-4.5)), "sg14::fixed_point test failed");
 
-static_assert(fixed_point<uint8_t>(4.5) <= fixed_point<int16_t>(4.5), "sg14::fixed_point test failed");
-static_assert(!(fixed_point<uint8_t>(4.5) <= fixed_point<int16_t>(-4.5)), "sg14::fixed_point test failed");
+static_assert(fixed_point<uint8_t, -4>(4.5) <= fixed_point<int16_t, -8>(4.5), "sg14::fixed_point test failed");
+static_assert(!(fixed_point<uint8_t, -4>(4.5) <= fixed_point<int16_t, -8>(-4.5)), "sg14::fixed_point test failed");
 
-static_assert(fixed_point<uint8_t>(4.5) >= fixed_point<int16_t>(4.5), "sg14::fixed_point test failed");
-static_assert(fixed_point<uint8_t>(4.5) >= fixed_point<int16_t>(-4.5), "sg14::fixed_point test failed");
-static_assert(!(fixed_point<uint8_t>(4.5) >= fixed_point<int16_t>(4.6)), "sg14::fixed_point test failed");
+static_assert(fixed_point<uint8_t, -4>(4.5) >= fixed_point<int16_t, -8>(4.5), "sg14::fixed_point test failed");
+static_assert(fixed_point<uint8_t, -4>(4.5) >= fixed_point<int16_t, -8>(-4.5), "sg14::fixed_point test failed");
+static_assert(!(fixed_point<uint8_t, -4>(4.5) >= fixed_point<int16_t, -8>(4.6)), "sg14::fixed_point test failed");
 
 // TODO: Is this acceptable?
 static_assert(fixed_point<uint8_t, -1>(.5) == fixed_point<uint8_t, 0>(0), "sg14::fixed_point test failed");

--- a/src/fixed_point_test.cpp
+++ b/src/fixed_point_test.cpp
@@ -286,9 +286,14 @@ static_assert(make_fixed_from_repr<std::int32_t, 27>::integer_digits == 27, "sg1
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::common_type
 
-static_assert(std::is_same<common_type<fixed_point<std::uint8_t, -4>, fixed_point<std::int8_t, -4>>, fixed_point<int8_t, -3>>::value, "sg14::common_type");
-static_assert(std::is_same<common_type<fixed_point<std::int16_t, -4>, fixed_point<std::int32_t, -14>>, fixed_point<int32_t, -14>>::value, "sg14::common_type");
-static_assert(std::is_same<common_type<fixed_point<std::int16_t, 0>, fixed_point<std::uint64_t, -60>>, fixed_point<int64_t, -48>>::value, "sg14::common_type");
+// conversion never occurs when inputs are the same type
+static_assert(std::is_same<_impl::common_type<fixed_point<std::int8_t, -3>, fixed_point<std::int8_t, -3>>, fixed_point<int8_t, -3>>::value, "sg14::common_type");
+static_assert(std::is_same<_impl::common_type<fixed_point<std::int32_t, -14>, fixed_point<std::int32_t, -14>>, fixed_point<int32_t, -14>>::value, "sg14::common_type");
+static_assert(std::is_same<_impl::common_type<fixed_point<std::int64_t, -48>, fixed_point<std::int64_t, -48>>, fixed_point<int64_t, -48>>::value, "sg14::common_type");
+
+static_assert(std::is_same<_impl::common_type<fixed_point<std::uint8_t, -4>, fixed_point<std::int8_t, -4>>, fixed_point<int8_t, -3>>::value, "sg14::common_type");
+static_assert(std::is_same<_impl::common_type<fixed_point<std::int16_t, -4>, fixed_point<std::int32_t, -14>>, fixed_point<int32_t, -14>>::value, "sg14::common_type");
+static_assert(std::is_same<_impl::common_type<fixed_point<std::int16_t, 0>, fixed_point<std::uint64_t, -60>>, fixed_point<int64_t, -48>>::value, "sg14::common_type");
 
 ////////////////////////////////////////////////////////////////////////////////
 // comparison

--- a/src/fixed_point_test.cpp
+++ b/src/fixed_point_test.cpp
@@ -1,142 +1,32 @@
-#include "fixed_point.h"
+#include <fixed_point_utils.h>
 
-#include <cassert>
-#include <iostream>
+#include "test_utils.h"
 
 using namespace sg14;
 
-#define ASSERT_EQUAL(A, B) \
-	if ((A) != (B)) { \
-		cout << "Failed: \"" << #A " == " #B << "\", i.e. " << (A) << " != " << (B) << endl; \
-		assert(false); \
-	}
-
-#define ASSERT_TRUE(A) \
-	if (!(A)) { \
-		cout << "Failed: (" << #A << ") where (" #A "==" << (A) << ')' << endl; \
-		assert(false); \
-	}
-
-namespace sg14_test
+void fixed_point_test()
 {
-	namespace
-	{
-		template <typename FP>
-		constexpr auto magnitude(FP const & x, FP const & y, FP const & z)
-		-> decltype(trunc_sqrt(trunc_add(trunc_square(x), trunc_square(y), trunc_square(z))))
-		{
-			return trunc_sqrt(trunc_add(trunc_square(x), trunc_square(y), trunc_square(z)));
-		}
-	}
+	using namespace std;
 
-	void fixed_point_test()
-	{
-		using namespace std;
+	////////////////////////////////////////////////////////////////////////////////
+	// copy assignment
 
-		////////////////////////////////////////////////////////////////////////////////
-		// copy assignment
+	// from fixed_point
+	auto rhs = fixed_point<>(123.456);
+	auto lhs = rhs;
+	ASSERT_EQUAL(lhs, fixed_point<>(123.456));
 
-		// from fixed_point
-		auto rhs = fixed_point<>(123.456);
-		auto lhs = rhs;
-		ASSERT_EQUAL(lhs, fixed_point<>(123.456));
+	// from floating-point type
+	lhs = 234.567;
+	ASSERT_EQUAL(static_cast<double>(lhs), 234.56698608398438);
 
-		// from floating-point type
-		lhs = 234.567;
-		ASSERT_EQUAL(static_cast<double>(lhs), 234.56698608398438);
+	// from integer
+	lhs = 543;
+	ASSERT_EQUAL(static_cast<int>(lhs), 543);
 
-		// from integer
-		lhs = 543;
-		ASSERT_EQUAL(static_cast<int>(lhs), 543);
-
-		// from alternative specialization
-		lhs = fixed_point<uint8_t>(87.65);
-		ASSERT_EQUAL(static_cast<fixed_point<uint8_t>>(lhs), fixed_point<uint8_t>(87.65));
-
-		////////////////////////////////////////////////////////////////////////////////
-		// sin
-
-		ASSERT_EQUAL(static_cast<float>(sin(fixed_point<std::uint8_t, -6>(0))), 0);
-		ASSERT_EQUAL(static_cast<float>(sin(fixed_point<std::int16_t, -13>(3.1415926))), 0);
-		ASSERT_EQUAL(static_cast<double>(sin(fixed_point<std::uint16_t, -14>(3.1415926 / 2))), 1);
-		ASSERT_EQUAL(static_cast<float>(sin(fixed_point<std::int32_t, -24>(3.1415926 * 7. / 2.))), -1);
-		ASSERT_EQUAL(static_cast<float>(sin(fixed_point<std::int32_t, -28>(3.1415926 / 4))), .707106769f);
-		ASSERT_EQUAL(static_cast<double>(sin(fixed_point<std::int16_t, -10>(-3.1415926 / 3))), -.865234375);
-
-		////////////////////////////////////////////////////////////////////////////////
-		// cos
-
-		ASSERT_EQUAL(static_cast<float>(cos(fixed_point<std::uint8_t, -6>(0))), 1);
-		ASSERT_EQUAL(static_cast<float>(cos(fixed_point<std::int16_t, -13>(3.1415926))), -1);
-		ASSERT_EQUAL(static_cast<double>(cos(fixed_point<std::uint16_t, -14>(3.1415926 / 2))), 0);
-		ASSERT_EQUAL(static_cast<float>(cos(fixed_point<std::int32_t, -20>(3.1415926 * 7. / 2.))), 0);
-		ASSERT_EQUAL(static_cast<float>(cos(fixed_point<std::int32_t, -28>(3.1415926 / 4))), .707106829f);
-		ASSERT_EQUAL(static_cast<double>(cos(fixed_point<std::int16_t, -10>(-3.1415926 / 3))), .5);
-
-		////////////////////////////////////////////////////////////////////////////////
-		// Tests of Examples in Proposal 
-
-		// Class Template
-
-		static_assert(fixed_point<uint16_t>::integer_digits == 8, "Incorrect information in proposal section, Class Template");
-		static_assert(fixed_point<uint16_t>::fractional_digits == 8, "Incorrect information in proposal section, Class Template");
-
-		static_assert(static_cast<float>(fixed_point<int32_t, -1>(10.5)) == 10.5, "Incorrect information in proposal section, Class Template");
-
-		static_assert(static_cast<float>(fixed_point<uint8_t, -8>(0)) == 0, "Incorrect information in proposal section, Class Template");
-		static_assert(static_cast<float>(fixed_point<uint8_t, -8>(.999999)) < 1, "Incorrect information in proposal section, Class Template");
-		static_assert(static_cast<float>(fixed_point<uint8_t, -8>(.999999)) > .99, "Incorrect information in proposal section, Class Template");
-		
-		static_assert(fixed_point<>::fractional_digits == _impl::num_bits<int>() / 2, "Incorrect information in proposal section, Class Template");
-
-		// Conversion
-
-		auto conversion_lhs = make_ufixed<4, 4>(.006);
-		auto conversion_rhs = make_ufixed<4, 4>(0);
-		static_assert(is_same<decltype(conversion_lhs), decltype(conversion_rhs)>::value, "Incorrect information in proposal section, Conversion");
-		ASSERT_EQUAL(conversion_lhs, conversion_rhs);
-
-		// Arithmetic Operators (Overflow)
-		static_assert(static_cast<int>(make_fixed<4, 3>(15) + make_fixed<4, 3>(1)) != 16, "Incorrect information in proposal section, Overflow");
-
-		// Arithmetic Operators (Underflow)
-		static_assert(static_cast<float>(make_fixed<7, 0>(15) / make_fixed<7, 0>(2)) == 7, "Incorrect information in proposal section, Underflow");
-
-		// Type Promotion
-		auto type_promotion = promote(make_fixed<5, 2>(15.5));
-		static_assert(is_same<decltype(type_promotion), make_fixed<11, 4>>::value, "Incorrect information in proposal section, Type Promotion and Demotion Functions");
-		ASSERT_EQUAL(static_cast<float>(type_promotion), 15.5);
-
-		// Named Arithmetic Functions
-		auto sq = trunc_multiply(make_ufixed<4, 4>(15.9375), make_ufixed<4, 4>(15.9375));
-		ASSERT_EQUAL(static_cast<double>(sq), 254);
-
-		auto most_negative = make_fixed<7, 0>(-128);
-		ASSERT_EQUAL(static_cast<int>(most_negative), -128);
-		ASSERT_EQUAL(static_cast<int>(trunc_square(promote(most_negative))), 16384);
-		auto square = trunc_square(most_negative);
-		static_assert(is_same<decltype(square), fixed_point<uint8_t, 6>>::value, "wrong type mentioned in proposal");
-		ASSERT_EQUAL(static_cast<int>(square), 0);
-
-		// Underflow
-		static_assert(static_cast<int>(trunc_square(make_ufixed<8, 0>(15))) != 15 * 15, "wrong behavior reported in 'Overflow and Underflow' section");
-
-		// Examples
-		static_assert(static_cast<double>(magnitude(
-			make_ufixed<4, 12>(1),
-			make_ufixed<4, 12>(4),
-			make_ufixed<4, 12>(9))) == 9.890625, "unexpected result from magnitude");
-
-		static fixed_point<> zero;
-		ASSERT_EQUAL(zero, fixed_point<>(0));
-
-		// Bounded Integers
-		make_ufixed<2, 6> three(3);
-		auto n = trunc_square(trunc_square(three));
-		ASSERT_EQUAL(static_cast<int>(n), 81);
-		static_assert(is_same<decltype(n), make_ufixed<8, 0>>::value, "bad assumption about type in 'Bounded Integers' section");
-		ASSERT_EQUAL(static_cast<int>(make_ufixed<7, 1>(81)), 81);
-	}
+	// from alternative specialization
+	lhs = fixed_point<uint8_t>(87.65);
+	ASSERT_EQUAL(static_cast<fixed_point<uint8_t>>(lhs), fixed_point<uint8_t>(87.65));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -535,15 +425,6 @@ static_assert(std::is_same<promote_square_result_t<make_fixed<6, 25>>, make_ufix
 static_assert(static_cast<float>(promote_square(make_ufixed<7, 1>(127.5))) == 16256.25, "sg14::promote_square test failed");
 static_assert(static_cast<float>(promote_square(make_ufixed<4, 4>(15.5))) == 240.25, "sg14::promote_square test failed");
 static_assert(static_cast<std::uint64_t>(promote_square(make_fixed<31>(2000000000))) == 4000000000000000000, "sg14::promote_square test failed");
-
-////////////////////////////////////////////////////////////////////////////////
-// sg14::abs
-
-static_assert(static_cast<int>(abs(make_fixed<7, 0>(66))) == 66, "sg14::abs test failed");
-static_assert(static_cast<int>(abs(make_fixed<7, 0>(-123))) == 123, "sg14::abs test failed");
-static_assert(static_cast<std::int64_t>(abs(make_fixed<63, 0>(9223372036854775807))) == 9223372036854775807, "sg14::abs test failed");
-static_assert(static_cast<std::int64_t>(abs(make_fixed<63, 0>(-9223372036854775807))) == 9223372036854775807, "sg14::abs test failed");
-static_assert(static_cast<int>(abs(make_fixed<7, 8>(-5))) == 5, "sg14::abs test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::sqrt

--- a/src/fixed_point_utils_test.cpp
+++ b/src/fixed_point_utils_test.cpp
@@ -1,0 +1,38 @@
+#include <fixed_point_utils.h>
+
+#include "test_utils.h"
+
+using namespace std;
+using namespace sg14;
+
+void fixed_point_utils_test()
+{
+	////////////////////////////////////////////////////////////////////////////////
+	// sin
+
+	ASSERT_EQUAL(static_cast<float>(sin(fixed_point<std::uint8_t, -6>(0))), 0);
+	ASSERT_EQUAL(static_cast<float>(sin(fixed_point<std::int16_t, -13>(3.1415926))), 0);
+	ASSERT_EQUAL(static_cast<double>(sin(fixed_point<std::uint16_t, -14>(3.1415926 / 2))), 1);
+	ASSERT_EQUAL(static_cast<float>(sin(fixed_point<std::int32_t, -24>(3.1415926 * 7. / 2.))), -1);
+	ASSERT_EQUAL(static_cast<float>(sin(fixed_point<std::int32_t, -28>(3.1415926 / 4))), .707106769f);
+	ASSERT_EQUAL(static_cast<double>(sin(fixed_point<std::int16_t, -10>(-3.1415926 / 3))), -.865234375);
+
+	////////////////////////////////////////////////////////////////////////////////
+	// cos
+
+	ASSERT_EQUAL(static_cast<float>(cos(fixed_point<std::uint8_t, -6>(0))), 1);
+	ASSERT_EQUAL(static_cast<float>(cos(fixed_point<std::int16_t, -13>(3.1415926))), -1);
+	ASSERT_EQUAL(static_cast<double>(cos(fixed_point<std::uint16_t, -14>(3.1415926 / 2))), 0);
+	ASSERT_EQUAL(static_cast<float>(cos(fixed_point<std::int32_t, -20>(3.1415926 * 7. / 2.))), 0);
+	ASSERT_EQUAL(static_cast<float>(cos(fixed_point<std::int32_t, -28>(3.1415926 / 4))), .707106829f);
+	ASSERT_EQUAL(static_cast<double>(cos(fixed_point<std::int16_t, -10>(-3.1415926 / 3))), .5);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// sg14::abs
+
+static_assert(static_cast<int>(abs(make_fixed<7, 0>(66))) == 66, "sg14::abs test failed");
+static_assert(static_cast<int>(abs(make_fixed<7, 0>(-123))) == 123, "sg14::abs test failed");
+static_assert(static_cast<std::int64_t>(abs(make_fixed<63, 0>(9223372036854775807))) == 9223372036854775807, "sg14::abs test failed");
+static_assert(static_cast<std::int64_t>(abs(make_fixed<63, 0>(-9223372036854775807))) == 9223372036854775807, "sg14::abs test failed");
+static_assert(static_cast<int>(abs(make_fixed<7, 8>(-5))) == 5, "sg14::abs test failed");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,12 @@
-namespace sg14_test
-{
-	void fixed_point_test();
-}
+void fixed_point_test();
+void fixed_point_utils_test();
+void proposal_test();
 
 int main(int, char *[])
 {
-	sg14_test::fixed_point_test();
+	fixed_point_test();
+	fixed_point_utils_test();
+	proposal_test();
 
 	return 0;
 }

--- a/src/proposal_test.cpp
+++ b/src/proposal_test.cpp
@@ -22,8 +22,8 @@ void proposal_test()
 
 	// Class Template
 
-	static_assert(fixed_point<uint16_t>::integer_digits == 8, "Incorrect information in proposal section, Class Template");
-	static_assert(fixed_point<uint16_t>::fractional_digits == 8, "Incorrect information in proposal section, Class Template");
+	static_assert(fixed_point<uint16_t>::integer_digits == 16, "Incorrect information in proposal section, Class Template");
+	static_assert(fixed_point<uint16_t>::fractional_digits == 0, "Incorrect information in proposal section, Class Template");
 
 	static_assert(static_cast<float>(fixed_point<int32_t, -1>(10.5)) == 10.5, "Incorrect information in proposal section, Class Template");
 
@@ -31,7 +31,7 @@ void proposal_test()
 	static_assert(static_cast<float>(fixed_point<uint8_t, -8>(.999999)) < 1, "Incorrect information in proposal section, Class Template");
 	static_assert(static_cast<float>(fixed_point<uint8_t, -8>(.999999)) > .99, "Incorrect information in proposal section, Class Template");
 
-	static_assert(fixed_point<>::fractional_digits == _impl::num_bits<int>() / 2, "Incorrect information in proposal section, Class Template");
+	static_assert(fixed_point<>::fractional_digits == 0, "Incorrect information in proposal section, Class Template");
 
 	// Conversion
 

--- a/src/proposal_test.cpp
+++ b/src/proposal_test.cpp
@@ -1,0 +1,83 @@
+#include <fixed_point_utils.h>
+
+#include "test_utils.h"
+
+namespace
+{
+	template <typename FP>
+	constexpr auto magnitude(FP const & x, FP const & y, FP const & z)
+	-> decltype(trunc_sqrt(trunc_add(trunc_square(x), trunc_square(y), trunc_square(z))))
+	{
+		return trunc_sqrt(trunc_add(trunc_square(x), trunc_square(y), trunc_square(z)));
+	}
+}
+
+void proposal_test()
+{
+	using namespace std;
+	using namespace sg14;
+
+	////////////////////////////////////////////////////////////////////////////////
+	// Tests of Examples in Proposal 
+
+	// Class Template
+
+	static_assert(fixed_point<uint16_t>::integer_digits == 8, "Incorrect information in proposal section, Class Template");
+	static_assert(fixed_point<uint16_t>::fractional_digits == 8, "Incorrect information in proposal section, Class Template");
+
+	static_assert(static_cast<float>(fixed_point<int32_t, -1>(10.5)) == 10.5, "Incorrect information in proposal section, Class Template");
+
+	static_assert(static_cast<float>(fixed_point<uint8_t, -8>(0)) == 0, "Incorrect information in proposal section, Class Template");
+	static_assert(static_cast<float>(fixed_point<uint8_t, -8>(.999999)) < 1, "Incorrect information in proposal section, Class Template");
+	static_assert(static_cast<float>(fixed_point<uint8_t, -8>(.999999)) > .99, "Incorrect information in proposal section, Class Template");
+
+	static_assert(fixed_point<>::fractional_digits == _impl::num_bits<int>() / 2, "Incorrect information in proposal section, Class Template");
+
+	// Conversion
+
+	auto conversion_lhs = make_ufixed<4, 4>(.006);
+	auto conversion_rhs = make_ufixed<4, 4>(0);
+	static_assert(is_same<decltype(conversion_lhs), decltype(conversion_rhs)>::value, "Incorrect information in proposal section, Conversion");
+	ASSERT_EQUAL(conversion_lhs, conversion_rhs);
+
+	// Arithmetic Operators (Overflow)
+	static_assert(static_cast<int>(make_fixed<4, 3>(15) + make_fixed<4, 3>(1)) != 16, "Incorrect information in proposal section, Overflow");
+
+	// Arithmetic Operators (Underflow)
+	static_assert(static_cast<float>(make_fixed<7, 0>(15) / make_fixed<7, 0>(2)) == 7, "Incorrect information in proposal section, Underflow");
+
+	// Type Promotion
+	auto type_promotion = promote(make_fixed<5, 2>(15.5));
+	static_assert(is_same<decltype(type_promotion), make_fixed<11, 4>>::value, "Incorrect information in proposal section, Type Promotion and Demotion Functions");
+	ASSERT_EQUAL(static_cast<float>(type_promotion), 15.5);
+
+	// Named Arithmetic Functions
+	auto sq = trunc_multiply(make_ufixed<4, 4>(15.9375), make_ufixed<4, 4>(15.9375));
+	ASSERT_EQUAL(static_cast<double>(sq), 254);
+
+	auto most_negative = make_fixed<7, 0>(-128);
+	ASSERT_EQUAL(static_cast<int>(most_negative), -128);
+	ASSERT_EQUAL(static_cast<int>(trunc_square(promote(most_negative))), 16384);
+	auto square = trunc_square(most_negative);
+	static_assert(is_same<decltype(square), fixed_point<uint8_t, 6>>::value, "wrong type mentioned in proposal");
+	ASSERT_EQUAL(static_cast<int>(square), 0);
+
+	// Underflow
+	static_assert(static_cast<int>(trunc_square(make_ufixed<8, 0>(15))) != 15 * 15, "wrong behavior reported in 'Overflow and Underflow' section");
+
+	// Examples
+	static_assert(static_cast<double>(magnitude(
+		make_ufixed<4, 12>(1),
+		make_ufixed<4, 12>(4),
+		make_ufixed<4, 12>(9))) == 9.890625, "unexpected result from magnitude");
+
+	static fixed_point<> zero;
+	ASSERT_EQUAL(zero, fixed_point<>(0));
+
+	// Bounded Integers
+	make_ufixed<2, 6> three(3);
+	auto n = trunc_square(trunc_square(three));
+	ASSERT_EQUAL(static_cast<int>(n), 81);
+	static_assert(is_same<decltype(n), make_ufixed<8, 0>>::value, "bad assumption about type in 'Bounded Integers' section");
+	ASSERT_EQUAL(static_cast<int>(make_ufixed<7, 1>(81)), 81);
+}

--- a/src/test_utils.h
+++ b/src/test_utils.h
@@ -1,0 +1,19 @@
+#ifndef _SG14_TEST_UTILS_H
+#define _SG14_TEST_UTILS_H
+
+#include <cassert>
+#include <iostream>
+
+#define ASSERT_EQUAL(A, B) \
+	if ((A) != (B)) { \
+		cout << "Failed: \"" << #A " == " #B << "\", i.e. " << (A) << " != " << (B) << endl; \
+		assert(false); \
+	}
+
+#define ASSERT_TRUE(A) \
+	if (!(A)) { \
+		cout << "Failed: (" << #A << ") where (" #A "==" << (A) << ')' << endl; \
+		assert(false); \
+	}
+
+#endif // _SG14_TEST_UTILS_H

--- a/vs/fixed_point_test.sln
+++ b/vs/fixed_point_test.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fixed_point_test", "fixed_point_test.vcxproj", "{50975066-6B9B-41DD-9BC7-B24C3B896B61}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{50975066-6B9B-41DD-9BC7-B24C3B896B61}.Debug|x64.ActiveCfg = Debug|x64
+		{50975066-6B9B-41DD-9BC7-B24C3B896B61}.Debug|x64.Build.0 = Debug|x64
+		{50975066-6B9B-41DD-9BC7-B24C3B896B61}.Debug|x86.ActiveCfg = Debug|Win32
+		{50975066-6B9B-41DD-9BC7-B24C3B896B61}.Debug|x86.Build.0 = Debug|Win32
+		{50975066-6B9B-41DD-9BC7-B24C3B896B61}.Release|x64.ActiveCfg = Release|x64
+		{50975066-6B9B-41DD-9BC7-B24C3B896B61}.Release|x64.Build.0 = Release|x64
+		{50975066-6B9B-41DD-9BC7-B24C3B896B61}.Release|x86.ActiveCfg = Release|Win32
+		{50975066-6B9B-41DD-9BC7-B24C3B896B61}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/vs/fixed_point_test.vcxproj
+++ b/vs/fixed_point_test.vcxproj
@@ -1,0 +1,160 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{50975066-6B9B-41DD-9BC7-B24C3B896B61}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>fixed_point_test</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../include</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../include</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\include\fixed_point.h" />
+    <ClInclude Include="..\include\fixed_point_utils.h" />
+    <ClInclude Include="..\src\test_utils.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\fixed_point_test.cpp" />
+    <ClCompile Include="..\src\fixed_point_utils_test.cpp" />
+    <ClCompile Include="..\src\main.cpp" />
+    <ClCompile Include="..\src\proposal_test.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/vs/fixed_point_test.vcxproj.filters
+++ b/vs/fixed_point_test.vcxproj.filters
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\include\fixed_point.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\fixed_point_utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\test_utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\fixed_point_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\fixed_point_utils_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\proposal_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/vs/fixed_point_test.vcxproj.user
+++ b/vs/fixed_point_test.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>


### PR DESCRIPTION
Major changes:
- adds _fixed_point_utils.h_ with definitions from _fixed_point.h_ which are not currently part of the [proposal](https://github.com/WG21-SG14/SG14/blob/master/Docs/Proposals/Fixed_Point_Library_Proposal.md);
- adds Visual Studio 2015 project files;
- breaks tests into three separate files.

API changes:
- default value of `fixed_point` class template parameter `Exponent` changed to 0.
