### PR TITLE
Mixed type

### DIFF
--- a/include/fixed_point.h
+++ b/include/fixed_point.h
@@ -1149,6 +1149,26 @@ namespace sg14
 	}
 
 	////////////////////////////////////////////////////////////////////////////////
+	// sg14::trunc_divide_result_t / trunc_divide
+
+	// yields specialization of fixed_point with integral bits necessary to store
+	// result of a divide between values of fixed_point<ReprType, Exponent>
+	template <class Lhs, class Rhs = Lhs>
+	using trunc_divide_result_t = make_fixed_from_repr<
+		_impl::common_repr_type<typename Lhs::repr_type, typename Rhs::repr_type>,
+		Lhs::integer_digits + Rhs::fractional_digits>;
+
+	// as trunc_divide_result_t but converts parameter, factor,
+	// ready for safe binary divide
+	template <class Lhs, class Rhs>
+	trunc_divide_result_t<Lhs, Rhs>
+	constexpr trunc_divide(const Lhs & lhs, const Rhs & rhs) noexcept
+	{
+		using result_type = trunc_divide_result_t<Lhs, Rhs>;
+		return _impl::divide<result_type>(lhs, rhs);
+	}
+
+	////////////////////////////////////////////////////////////////////////////////
 	// sg14::trunc_square_result_t / trunc_square
 
 	// yields specialization of fixed_point with integral bits necessary to store

--- a/include/fixed_point.h
+++ b/include/fixed_point.h
@@ -667,15 +667,13 @@ namespace sg14
 
 		// given a fixed-point and a integer type, 
 		// generates a fixed-point type that is as big as both of them (or as close as possible)
-		template <class LhsReprType, int LhsExponent, class Integer>
+		template <class LhsReprType, int LhsExponent, class RhsInteger>
 		struct _common_type<
 			fixed_point<LhsReprType, LhsExponent>,
-			Integer,
-			typename std::enable_if<_impl::is_integral<Integer>::value>::type>
-		: _common_type<
-			fixed_point<LhsReprType, LhsExponent>,
-			fixed_point<Integer>>
+			RhsInteger,
+			typename std::enable_if<_impl::is_integral<RhsInteger>::value>::type>
 		{
+			using type = fixed_point<LhsReprType, LhsExponent>;
 		};
 
 		// given a fixed-point and a floating-point type, 

--- a/include/fixed_point.h
+++ b/include/fixed_point.h
@@ -720,18 +720,20 @@ namespace sg14
 		////////////////////////////////////////////////////////////////////////////////
 		// sg14::_impl::divide
 
-		template <class Result, class Lhs, class Rhs>
-		constexpr Result divide(const Lhs & lhs, const Rhs & rhs) noexcept
+		template <class FixedPointQuotient, class FixedPointDividend, class FixedPointDivisor>
+		constexpr FixedPointQuotient divide(const FixedPointDividend & lhs, const FixedPointDivisor & rhs) noexcept
 		{
-			using result_repr_type = typename Result::repr_type;
-			using common_type = typename _impl::common_type<Lhs, Rhs>;
+			using result_repr_type = typename FixedPointQuotient::repr_type;
+			using common_type = typename _impl::common_type<FixedPointDividend, FixedPointDivisor>;
 			using common_repr_type = typename common_type::repr_type;
 			using intermediate_repr_type = _impl::next_size_t<common_repr_type>;
 
-			return Result::from_data(
-				_impl::shift_left<(Lhs::exponent - Rhs::exponent - Result::exponent - num_bits<common_repr_type>()), result_repr_type>(
-					(_impl::shift_left<(num_bits<common_repr_type>()), intermediate_repr_type>(lhs.data())) 
-						/ rhs.data()));
+			return FixedPointQuotient::from_data(
+				_impl::shift_left<(
+					FixedPointDividend::exponent - FixedPointDivisor::exponent - FixedPointQuotient::exponent - num_bits<common_repr_type>()),
+					result_repr_type>(
+						(_impl::shift_left<(num_bits<common_repr_type>()), intermediate_repr_type>(lhs.data()))
+							/ rhs.data()));
 		}
 
 		////////////////////////////////////////////////////////////////////////////////
@@ -1152,19 +1154,19 @@ namespace sg14
 	// sg14::trunc_divide_result_t / trunc_divide
 
 	// yields specialization of fixed_point with integral bits necessary to store
-	// result of a divide between values of fixed_point<ReprType, Exponent>
-	template <class Lhs, class Rhs = Lhs>
+	// result of a divide between values of types, Lhs and Rhs
+	template <class FixedPointDividend, class FixedPointDivisor = FixedPointDividend>
 	using trunc_divide_result_t = make_fixed_from_repr<
-		_impl::common_repr_type<typename Lhs::repr_type, typename Rhs::repr_type>,
-		Lhs::integer_digits + Rhs::fractional_digits>;
+		_impl::common_repr_type<typename FixedPointDividend::repr_type, typename FixedPointDivisor::repr_type>,
+		FixedPointDividend::integer_digits + FixedPointDivisor::fractional_digits>;
 
 	// as trunc_divide_result_t but converts parameter, factor,
 	// ready for safe binary divide
-	template <class Lhs, class Rhs>
-	trunc_divide_result_t<Lhs, Rhs>
-	constexpr trunc_divide(const Lhs & lhs, const Rhs & rhs) noexcept
+	template <class FixedPointDividend, class FixedPointDivisor>
+	trunc_divide_result_t<FixedPointDividend, FixedPointDivisor>
+	constexpr trunc_divide(const FixedPointDividend & lhs, const FixedPointDivisor & rhs) noexcept
 	{
-		using result_type = trunc_divide_result_t<Lhs, Rhs>;
+		using result_type = trunc_divide_result_t<FixedPointDividend, FixedPointDivisor>;
 		return _impl::divide<result_type>(lhs, rhs);
 	}
 

--- a/src/fixed_point_test.cpp
+++ b/src/fixed_point_test.cpp
@@ -3,6 +3,7 @@
 #include "test_utils.h"
 
 using namespace sg14;
+using namespace std;
 
 void fixed_point_test()
 {
@@ -63,7 +64,7 @@ static_assert(static_cast<int>(-3.0) == -3, "incorrect assumption about default 
 static_assert(static_cast<int>(-3.9) == -3, "incorrect assumption about default rounding");
 
 // mixed-mode operations DO lose precision because exponent is more important than significand
-static_assert(std::is_same<std::common_type<float, std::uint32_t>::type, float>::value, "incorrect assumption about promotion");
+static_assert(is_same<common_type<float, uint32_t>::type, float>::value, "incorrect assumption about promotion");
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -77,28 +78,28 @@ static_assert(_impl::is_integral<int>(), "sg14::_impl::is_integral test failed")
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::_impl::shift_left/right positive RHS
 
-static_assert(_impl::shift_left<8, std::uint16_t>((std::uint16_t)0x1234) == 0x3400, "sg14::_impl::shift_left test failed");
-static_assert(_impl::shift_left<8, std::uint16_t>((std::uint8_t)0x1234) == 0x3400, "sg14::_impl::shift_left test failed");
-static_assert(_impl::shift_left<8, std::uint8_t>((std::uint16_t)0x1234) == 0x0, "sg14::_impl::shift_left test failed");
-static_assert(_impl::shift_left<8, std::int16_t>(-123) == -31488, "sg14::_impl::shift_left test failed");
+static_assert(_impl::shift_left<8, uint16_t>((uint16_t)0x1234) == 0x3400, "sg14::_impl::shift_left test failed");
+static_assert(_impl::shift_left<8, uint16_t>((uint8_t)0x1234) == 0x3400, "sg14::_impl::shift_left test failed");
+static_assert(_impl::shift_left<8, uint8_t>((uint16_t)0x1234) == 0x0, "sg14::_impl::shift_left test failed");
+static_assert(_impl::shift_left<8, int16_t>(-123) == -31488, "sg14::_impl::shift_left test failed");
 
-static_assert(_impl::shift_right<8, std::uint16_t>((std::uint16_t)0x1234) == 0x12, "sg14::_impl::shift_right test failed");
-static_assert(_impl::shift_right<8, std::uint16_t>((std::uint8_t)0x1234) == 0x0, "sg14::_impl::shift_right test failed");
-static_assert(_impl::shift_right<8, std::uint8_t>((std::uint16_t)0x1234) == 0x12, "sg14::_impl::shift_right test failed");
-static_assert(_impl::shift_right<8, std::int16_t>(-31488) == -123, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<8, uint16_t>((uint16_t)0x1234) == 0x12, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<8, uint16_t>((uint8_t)0x1234) == 0x0, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<8, uint8_t>((uint16_t)0x1234) == 0x12, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<8, int16_t>(-31488) == -123, "sg14::_impl::shift_right test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::_impl::shift_left/right negative RHS
 
-static_assert(_impl::shift_right<-8, std::uint16_t>((std::uint16_t)0x1234) == 0x3400, "sg14::_impl::shift_right test failed");
-static_assert(_impl::shift_right<-8, std::uint16_t>((std::uint8_t)0x1234) == 0x3400, "sg14::_impl::shift_right test failed");
-static_assert(_impl::shift_right<-8, std::uint8_t>((std::uint16_t)0x1234) == 0x0, "sg14::_impl::shift_right test failed");
-static_assert(_impl::shift_right<-8, std::int16_t>(-123) == -31488, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<-8, uint16_t>((uint16_t)0x1234) == 0x3400, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<-8, uint16_t>((uint8_t)0x1234) == 0x3400, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<-8, uint8_t>((uint16_t)0x1234) == 0x0, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<-8, int16_t>(-123) == -31488, "sg14::_impl::shift_right test failed");
 
-static_assert(_impl::shift_left<-8, std::uint16_t>((std::uint16_t)0x1234) == 0x12, "sg14::_impl::shift_left test failed");
-static_assert(_impl::shift_left<-8, std::uint16_t>((std::uint8_t)0x1234) == 0x0, "sg14::_impl::shift_left test failed");
-static_assert(_impl::shift_left<-8, std::uint8_t>((std::uint16_t)0x1234) == 0x12, "sg14::_impl::shift_left test failed");
-static_assert(_impl::shift_left<-8, std::int16_t>(-31488) == -123, "sg14::_impl::shift_left test failed");
+static_assert(_impl::shift_left<-8, uint16_t>((uint16_t)0x1234) == 0x12, "sg14::_impl::shift_left test failed");
+static_assert(_impl::shift_left<-8, uint16_t>((uint8_t)0x1234) == 0x0, "sg14::_impl::shift_left test failed");
+static_assert(_impl::shift_left<-8, uint8_t>((uint16_t)0x1234) == 0x12, "sg14::_impl::shift_left test failed");
+static_assert(_impl::shift_left<-8, int16_t>(-31488) == -123, "sg14::_impl::shift_left test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::_impl::pow2
@@ -127,31 +128,31 @@ static_assert(_impl::capacity<16>::value == 5, "sg14::_impl::capacity test faile
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::_impl::necessary_repr_t
 
-static_assert(std::is_same<_impl::necessary_repr_t<1, false>, std::uint8_t>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<1, true>, std::int8_t>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<8, false>, std::uint8_t>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<8, true>, std::int8_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<1, false>, uint8_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<1, true>, int8_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<8, false>, uint8_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<8, true>, int8_t>::value, "sg14::_impl::necessary_repr_t");
 
-static_assert(std::is_same<_impl::necessary_repr_t<9, false>, std::uint16_t>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<9, true>, std::int16_t>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<16, false>, std::uint16_t>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<16, true>, std::int16_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<9, false>, uint16_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<9, true>, int16_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<16, false>, uint16_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<16, true>, int16_t>::value, "sg14::_impl::necessary_repr_t");
 
-static_assert(std::is_same<_impl::necessary_repr_t<17, false>, std::uint32_t>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<17, true>, std::int32_t>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<32, false>, std::uint32_t>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<32, true>, std::int32_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<17, false>, uint32_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<17, true>, int32_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<32, false>, uint32_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<32, true>, int32_t>::value, "sg14::_impl::necessary_repr_t");
 
-static_assert(std::is_same<_impl::necessary_repr_t<33, false>, std::uint64_t>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<33, true>, std::int64_t>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<64, false>, std::uint64_t>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<64, true>, std::int64_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<33, false>, uint64_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<33, true>, int64_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<64, false>, uint64_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<64, true>, int64_t>::value, "sg14::_impl::necessary_repr_t");
 
 #if defined(_SG14_FIXED_POINT_128)
-static_assert(std::is_same<_impl::necessary_repr_t<65, false>, unsigned __int128>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<65, true>, __int128>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<128, false>, unsigned __int128>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<128, true>, __int128>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<65, false>, unsigned __int128>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<65, true>, __int128>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<128, false>, unsigned __int128>::value, "sg14::_impl::necessary_repr_t");
+static_assert(is_same<_impl::necessary_repr_t<128, true>, __int128>::value, "sg14::_impl::necessary_repr_t");
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -161,19 +162,19 @@ static_assert(std::is_same<_impl::necessary_repr_t<128, true>, __int128>::value,
 ////////////////////////////////////////////////////////////////////////////////
 // default second template parameter
 
-static_assert(std::is_same<fixed_point<std::int8_t>, fixed_point<std::int8_t, 0>>::value, "sg14::fixed_point test failed");
-static_assert(std::is_same<fixed_point<std::uint8_t>, fixed_point<std::uint8_t, 0>>::value, "sg14::fixed_point test failed");
-static_assert(std::is_same<fixed_point<std::int16_t>, fixed_point<std::int16_t, 0>>::value, "sg14::fixed_point test failed");
-static_assert(std::is_same<fixed_point<std::uint16_t>, fixed_point<std::uint16_t, 0>>::value, "sg14::fixed_point test failed");
-static_assert(std::is_same<fixed_point<std::int32_t>, fixed_point<std::int32_t, 0>>::value, "sg14::fixed_point test failed");
-static_assert(std::is_same<fixed_point<std::uint32_t>, fixed_point<std::uint32_t, 0>>::value, "sg14::fixed_point test failed");
-static_assert(std::is_same<fixed_point<std::int64_t>, fixed_point<std::int64_t, 0>>::value, "sg14::fixed_point test failed");
-static_assert(std::is_same<fixed_point<std::uint64_t>, fixed_point<std::uint64_t, 0>>::value, "sg14::fixed_point test failed");
+static_assert(is_same<fixed_point<int8_t>, fixed_point<int8_t, 0>>::value, "sg14::fixed_point test failed");
+static_assert(is_same<fixed_point<uint8_t>, fixed_point<uint8_t, 0>>::value, "sg14::fixed_point test failed");
+static_assert(is_same<fixed_point<int16_t>, fixed_point<int16_t, 0>>::value, "sg14::fixed_point test failed");
+static_assert(is_same<fixed_point<uint16_t>, fixed_point<uint16_t, 0>>::value, "sg14::fixed_point test failed");
+static_assert(is_same<fixed_point<int32_t>, fixed_point<int32_t, 0>>::value, "sg14::fixed_point test failed");
+static_assert(is_same<fixed_point<uint32_t>, fixed_point<uint32_t, 0>>::value, "sg14::fixed_point test failed");
+static_assert(is_same<fixed_point<int64_t>, fixed_point<int64_t, 0>>::value, "sg14::fixed_point test failed");
+static_assert(is_same<fixed_point<uint64_t>, fixed_point<uint64_t, 0>>::value, "sg14::fixed_point test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // default first template parameter
 
-static_assert(std::is_same<fixed_point<int, 0>, fixed_point<>>::value, "sg14::fixed_point test failed");
+static_assert(is_same<fixed_point<int, 0>, fixed_point<>>::value, "sg14::fixed_point test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // conversion
@@ -190,60 +191,60 @@ static_assert(make_fixed<31, 0>(-12.34f) == -12.f, "sg14::fixed_point test faile
 static_assert((make_fixed<63, 0>(-12.34f)) == -12.f, "sg14::fixed_point test failed");
 
 // exponent = -1
-static_assert(fixed_point<std::uint8_t, -1>(127.5) == 127.5, "sg14::fixed_point test failed");
+static_assert(fixed_point<uint8_t, -1>(127.5) == 127.5, "sg14::fixed_point test failed");
 
-static_assert(fixed_point<std::int8_t, -1>(63.5) == 63.5, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int8_t, -1>(-63.5) == -63.5, "sg14::fixed_point test failed");
+static_assert(fixed_point<int8_t, -1>(63.5) == 63.5, "sg14::fixed_point test failed");
+static_assert(fixed_point<int8_t, -1>(-63.5) == -63.5, "sg14::fixed_point test failed");
 
 // exponent == -7
-static_assert(fixed_point<std::uint8_t, -7>(.125f) == .125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint16_t, -8>(232.125f) == 232.125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint32_t, -7>(232.125f) == 232.125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint64_t, -7>(232.125f) == 232.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<uint8_t, -7>(.125f) == .125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<uint16_t, -8>(232.125f) == 232.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<uint32_t, -7>(232.125f) == 232.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<uint64_t, -7>(232.125f) == 232.125f, "sg14::fixed_point test failed");
 
-static_assert(fixed_point<std::int8_t, -7>(.125f) == .125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int16_t, -7>(123.125f) == 123.125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int32_t, -7>(123.125f) == 123.125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int64_t, -7>(123.125f) == 123.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<int8_t, -7>(.125f) == .125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<int16_t, -7>(123.125f) == 123.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<int32_t, -7>(123.125f) == 123.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<int64_t, -7>(123.125f) == 123.125f, "sg14::fixed_point test failed");
 
-static_assert((fixed_point<std::uint8_t, -7>(.125f)) == .125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint16_t, -8>(232.125f) == 232.125L, "sg14::fixed_point test failed");
-static_assert((fixed_point<std::uint32_t, -7>(232.125f)) == 232.125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint64_t, -7>(232.125f) == 232.125L, "sg14::fixed_point test failed");
+static_assert((fixed_point<uint8_t, -7>(.125f)) == .125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<uint16_t, -8>(232.125f) == 232.125L, "sg14::fixed_point test failed");
+static_assert((fixed_point<uint32_t, -7>(232.125f)) == 232.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<uint64_t, -7>(232.125f) == 232.125L, "sg14::fixed_point test failed");
 
-static_assert(fixed_point<std::int8_t, -7>(1) != 1.L, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int8_t, -7>(.5) == .5f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int8_t, -7>(.125f) == .125L, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int16_t, -7>(123.125f) == 123, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int32_t, -7>(123.125f) == 123.125, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int64_t, -7>(123.125l) == 123.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<int8_t, -7>(1) != 1.L, "sg14::fixed_point test failed");
+static_assert(fixed_point<int8_t, -7>(.5) == .5f, "sg14::fixed_point test failed");
+static_assert(fixed_point<int8_t, -7>(.125f) == .125L, "sg14::fixed_point test failed");
+static_assert(fixed_point<int16_t, -7>(123.125f) == 123, "sg14::fixed_point test failed");
+static_assert(fixed_point<int32_t, -7>(123.125f) == 123.125, "sg14::fixed_point test failed");
+static_assert(fixed_point<int64_t, -7>(123.125l) == 123.125f, "sg14::fixed_point test failed");
 
 // exponent == 16
-static_assert(fixed_point<std::uint8_t, 16>(65536) == 65536.f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint16_t, 16>(6553.) == 0, "sg14::fixed_point test failed");
-static_assert((fixed_point<std::uint32_t, 16>(4294967296l)) == 4294967296.f, "sg14::fixed_point test failed");
-static_assert((fixed_point<std::uint64_t, 16>(1125895611875328l)) == 1125895611875328l, "sg14::fixed_point test failed");
+static_assert(fixed_point<uint8_t, 16>(65536) == 65536.f, "sg14::fixed_point test failed");
+static_assert(fixed_point<uint16_t, 16>(6553.) == 0, "sg14::fixed_point test failed");
+static_assert((fixed_point<uint32_t, 16>(4294967296l)) == 4294967296.f, "sg14::fixed_point test failed");
+static_assert((fixed_point<uint64_t, 16>(1125895611875328l)) == 1125895611875328l, "sg14::fixed_point test failed");
 
-static_assert(fixed_point<std::int8_t, 16>(-65536) == -65536.f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int16_t, 16>(-6553.) == 0, "sg14::fixed_point test failed");
-static_assert((fixed_point<std::int32_t, 16>(-4294967296l)) == -4294967296.f, "sg14::fixed_point test failed");
-static_assert((fixed_point<std::int64_t, 16>(-1125895611875328l)) == -1125895611875328l, "sg14::fixed_point test failed");
+static_assert(fixed_point<int8_t, 16>(-65536) == -65536.f, "sg14::fixed_point test failed");
+static_assert(fixed_point<int16_t, 16>(-6553.) == 0, "sg14::fixed_point test failed");
+static_assert((fixed_point<int32_t, 16>(-4294967296l)) == -4294967296.f, "sg14::fixed_point test failed");
+static_assert((fixed_point<int64_t, 16>(-1125895611875328l)) == -1125895611875328l, "sg14::fixed_point test failed");
 
 // exponent = 1
-static_assert(fixed_point<std::uint8_t, 1>(510) == 510, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint8_t, 1>(511) == 510, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int8_t, 1>(123.5) == 122, "sg14::fixed_point test failed");
+static_assert(fixed_point<uint8_t, 1>(510) == 510, "sg14::fixed_point test failed");
+static_assert(fixed_point<uint8_t, 1>(511) == 510, "sg14::fixed_point test failed");
+static_assert(fixed_point<int8_t, 1>(123.5) == 122, "sg14::fixed_point test failed");
 
-static_assert(fixed_point<std::int8_t, 1>(255) == 254, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int8_t, 1>(254) == 254, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int8_t, 1>(-5) == -6, "sg14::fixed_point test failed");
+static_assert(fixed_point<int8_t, 1>(255) == 254, "sg14::fixed_point test failed");
+static_assert(fixed_point<int8_t, 1>(254) == 254, "sg14::fixed_point test failed");
+static_assert(fixed_point<int8_t, 1>(-5) == -6, "sg14::fixed_point test failed");
 
 // conversion between fixed_point specializations
 static_assert(make_ufixed<4, 4>(make_fixed<7, 8>(1.5)) == 1.5, "sg14::fixed_point test failed");
 static_assert(make_ufixed<8, 8>(make_fixed<3, 4>(3.25)) == 3.25, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint8_t, 4>(fixed_point<std::int16_t, -4>(768)) == 768, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint64_t, -48>(fixed_point<std::uint32_t, -24>(3.141592654)) > 3.1415923f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint64_t, -48>(fixed_point<std::uint32_t, -24>(3.141592654)) < 3.1415927f, "sg14::fixed_point test failed");
+static_assert(fixed_point<uint8_t, 4>(fixed_point<int16_t, -4>(768)) == 768, "sg14::fixed_point test failed");
+static_assert(fixed_point<uint64_t, -48>(fixed_point<uint32_t, -24>(3.141592654)) > 3.1415923f, "sg14::fixed_point test failed");
+static_assert(fixed_point<uint64_t, -48>(fixed_point<uint32_t, -24>(3.141592654)) < 3.1415927f, "sg14::fixed_point test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // boolean
@@ -274,56 +275,56 @@ static_assert((make_ufixed<56, 8>(1003006) * make_ufixed<56, 8>(7)) == 7021042, 
 #endif
 
 // division
-static_assert((fixed_point<std::int8_t, -1>(63) / fixed_point<std::int8_t, -1>(-4)) == -16, "sg14::fixed_point test failed");
-static_assert((fixed_point<std::int8_t, 1>(-255) / fixed_point<std::int8_t, 1>(-8)) == 32, "sg14::fixed_point test failed");
+static_assert((fixed_point<int8_t, -1>(63) / fixed_point<int8_t, -1>(-4)) == -16, "sg14::fixed_point test failed");
+static_assert((fixed_point<int8_t, 1>(-255) / fixed_point<int8_t, 1>(-8)) == 32, "sg14::fixed_point test failed");
 static_assert((make_fixed<31, 0>(-999) / make_fixed<31, 0>(3)) == -333, "sg14::fixed_point test failed");
 #if defined(_SG14_FIXED_POINT_128)
-static_assert(static_cast<int>((fixed_point<std::uint64_t, -8>(65535) / fixed_point<std::uint64_t, -8>(256))) == 255, "sg14::fixed_point test failed");
+static_assert(static_cast<int>((fixed_point<uint64_t, -8>(65535) / fixed_point<uint64_t, -8>(256))) == 255, "sg14::fixed_point test failed");
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point_promotion_t
 
-static_assert(std::is_same<fixed_point_promotion_t<fixed_point<std::int8_t, -4>>, fixed_point<std::int16_t, -8>>::value, "sg14::fixed_point_promotion_t test failed");
-static_assert(std::is_same<fixed_point_promotion_t<fixed_point<std::uint32_t, 44>>, fixed_point<std::uint64_t, 88>>::value, "sg14::fixed_point_promotion_t test failed");
+static_assert(is_same<fixed_point_promotion_t<fixed_point<int8_t, -4>>, fixed_point<int16_t, -8>>::value, "sg14::fixed_point_promotion_t test failed");
+static_assert(is_same<fixed_point_promotion_t<fixed_point<uint32_t, 44>>, fixed_point<uint64_t, 88>>::value, "sg14::fixed_point_promotion_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point_demotion_t
 
-static_assert(std::is_same<fixed_point<std::int8_t, -4>, fixed_point_demotion_t<fixed_point<std::int16_t, -9>>>::value, "sg14::fixed_point_demotion_t test failed");
-static_assert(std::is_same<fixed_point<std::uint32_t, 44>, fixed_point_demotion_t<fixed_point<std::uint64_t, 88>>>::value, "sg14::fixed_point_demotion_t test failed");
+static_assert(is_same<fixed_point<int8_t, -4>, fixed_point_demotion_t<fixed_point<int16_t, -9>>>::value, "sg14::fixed_point_demotion_t test failed");
+static_assert(is_same<fixed_point<uint32_t, 44>, fixed_point_demotion_t<fixed_point<uint64_t, 88>>>::value, "sg14::fixed_point_demotion_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::make_fixed_from_repr
 
-static_assert(make_fixed_from_repr<std::uint8_t, 8>::integer_digits == 8, "sg14::make_fixed_from_repr test failed");
-static_assert(make_fixed_from_repr<std::int32_t, 27>::integer_digits == 27, "sg14::make_fixed_from_repr test failed");
+static_assert(make_fixed_from_repr<uint8_t, 8>::integer_digits == 8, "sg14::make_fixed_from_repr test failed");
+static_assert(make_fixed_from_repr<int32_t, 27>::integer_digits == 27, "sg14::make_fixed_from_repr test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::_impl::common_type
 
 // commonality never occurs when inputs are the same fixed_point type
-static_assert(std::is_same<_impl::common_type<fixed_point<std::int8_t, -3>, fixed_point<std::int8_t, -3>>, fixed_point<int8_t, -3>>::value, "sg14::_impl::common_type test failed");
-static_assert(std::is_same<_impl::common_type<fixed_point<std::int32_t, -14>, fixed_point<std::int32_t, -14>>, fixed_point<int32_t, -14>>::value, "sg14::_impl::common_type test failed");
-static_assert(std::is_same<_impl::common_type<fixed_point<std::int64_t, -48>, fixed_point<std::int64_t, -48>>, fixed_point<int64_t, -48>>::value, "sg14::_impl::common_type test failed");
+static_assert(is_same<_impl::common_type<fixed_point<int8_t, -3>, fixed_point<int8_t, -3>>, fixed_point<int8_t, -3>>::value, "sg14::_impl::common_type test failed");
+static_assert(is_same<_impl::common_type<fixed_point<int32_t, -14>, fixed_point<int32_t, -14>>, fixed_point<int32_t, -14>>::value, "sg14::_impl::common_type test failed");
+static_assert(is_same<_impl::common_type<fixed_point<int64_t, -48>, fixed_point<int64_t, -48>>, fixed_point<int64_t, -48>>::value, "sg14::_impl::common_type test failed");
 
 // commonality between homogeneous fixed_point types
-static_assert(std::is_same<_impl::common_type<fixed_point<std::uint8_t, -4>, fixed_point<std::int8_t, -4>>, fixed_point<int8_t, -3>>::value, "sg14::_impl::common_type test failed");
-static_assert(std::is_same<_impl::common_type<fixed_point<std::int16_t, -4>, fixed_point<std::int32_t, -14>>, fixed_point<int32_t, -14>>::value, "v");
-static_assert(std::is_same<_impl::common_type<fixed_point<std::int16_t, 0>, fixed_point<std::uint64_t, -60>>, fixed_point<int64_t, -48>>::value, "sg14::_impl::common_type test failed");
+static_assert(is_same<_impl::common_type<fixed_point<uint8_t, -4>, fixed_point<int8_t, -4>>, fixed_point<int8_t, -3>>::value, "sg14::_impl::common_type test failed");
+static_assert(is_same<_impl::common_type<fixed_point<int16_t, -4>, fixed_point<int32_t, -14>>, fixed_point<int32_t, -14>>::value, "v");
+static_assert(is_same<_impl::common_type<fixed_point<int16_t, 0>, fixed_point<uint64_t, -60>>, fixed_point<int64_t, -48>>::value, "sg14::_impl::common_type test failed");
 
 // commonality between arithmetic and fixed_point types
-static_assert(std::is_same<_impl::common_type<float, fixed_point<std::int8_t, -4>>, float>::value, "sg14::_impl::common_type test failed");
-static_assert(std::is_same<_impl::common_type<double, fixed_point<std::int32_t, -14>>, double>::value, "sg14::_impl::common_type test failed");
-static_assert(std::is_same<_impl::common_type<std::int8_t, fixed_point<std::uint64_t, -60>>, fixed_point<std::int64_t, -56>>::value, "sg14::_impl::common_type test failed");
-static_assert(std::is_same<_impl::common_type<fixed_point<std::uint8_t, -4>, std::uint32_t>, fixed_point<uint32_t, 0>>::value, "sg14::_impl::common_type test failed");
-static_assert(std::is_same<_impl::common_type<fixed_point<std::int16_t, -4>, float>, float>::value, "sg14::_impl::common_type test failed");
-static_assert(std::is_same<_impl::common_type<fixed_point<std::int16_t, 0>, double>, double>::value, "sg14::_impl::common_type test failed");
+static_assert(is_same<_impl::common_type<float, fixed_point<int8_t, -4>>, float>::value, "sg14::_impl::common_type test failed");
+static_assert(is_same<_impl::common_type<double, fixed_point<int32_t, -14>>, double>::value, "sg14::_impl::common_type test failed");
+static_assert(is_same<_impl::common_type<int8_t, fixed_point<uint64_t, -60>>, fixed_point<int64_t, -56>>::value, "sg14::_impl::common_type test failed");
+static_assert(is_same<_impl::common_type<fixed_point<uint8_t, -4>, uint32_t>, fixed_point<uint32_t, 0>>::value, "sg14::_impl::common_type test failed");
+static_assert(is_same<_impl::common_type<fixed_point<int16_t, -4>, float>, float>::value, "sg14::_impl::common_type test failed");
+static_assert(is_same<_impl::common_type<fixed_point<int16_t, 0>, double>, double>::value, "sg14::_impl::common_type test failed");
 
 // commonality between two non-fixed-point types (won't compile)
-//static_assert(std::is_same<_impl::common_type<float, float>, float>::value, "sg14::_impl::common_type test failed");
-//static_assert(std::is_same<_impl::common_type<double, std::uint16_t>, double>::value, "sg14::_impl::common_type test failed");
-//static_assert(std::is_same<_impl::common_type<std::int8_t, std::int8_t>, fixed_point<std::int64_t, -56>>::value, "sg14::_impl::common_type test failed");
+//static_assert(is_same<_impl::common_type<float, float>, float>::value, "sg14::_impl::common_type test failed");
+//static_assert(is_same<_impl::common_type<double, uint16_t>, double>::value, "sg14::_impl::common_type test failed");
+//static_assert(is_same<_impl::common_type<int8_t, int8_t>, fixed_point<int64_t, -56>>::value, "sg14::_impl::common_type test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::_impl::multiply
@@ -376,60 +377,60 @@ static_assert(!(fixed_point<int32_t, -3>(-4.5) < -5.6), "sg14::fixed_point test 
 
 // addition
 static_assert(make_fixed<2, 5>(2.125) + make_fixed<2, 5>(-3.25) == -1.125f, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(make_fixed<2, 5>(2.125) + make_fixed<2, 5>(-3.25)), make_fixed<2, 5>>::value, "arithmetic operators test failed");
+static_assert(is_same<decltype(make_fixed<2, 5>(2.125) + make_fixed<2, 5>(-3.25)), make_fixed<2, 5>>::value, "arithmetic operators test failed");
 
-static_assert(fixed_point<std::uint8_t, 10>(10240) + 2048 == 12288, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(fixed_point<std::uint8_t, 10>(10240) + 2048), fixed_point<int, 0>>::value, "arithmetic operators test failed");
-static_assert(2048 + fixed_point<std::uint8_t, 10>(10240) == 12288, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(2048 + fixed_point<std::uint8_t, 10>(10240)), fixed_point<int, 0>>::value, "arithmetic operators test failed");
+static_assert(fixed_point<uint8_t, 10>(10240) + 2048 == 12288, "arithmetic operators test failed");
+static_assert(is_same<decltype(fixed_point<uint8_t, 10>(10240) + 2048), fixed_point<int, 0>>::value, "arithmetic operators test failed");
+static_assert(2048 + fixed_point<uint8_t, 10>(10240) == 12288, "arithmetic operators test failed");
+static_assert(is_same<decltype(2048 + fixed_point<uint8_t, 10>(10240)), fixed_point<int, 0>>::value, "arithmetic operators test failed");
 
 static_assert(765.432f + make_fixed<31, 32>(16777215.996093750) == 16777981.428100586, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(765.432f + make_fixed<31, 32>(16777215.996093750)), double>::value, "arithmetic operators test failed");
+static_assert(is_same<decltype(765.432f + make_fixed<31, 32>(16777215.996093750)), double>::value, "arithmetic operators test failed");
 static_assert(make_fixed<31, 32>(16777215.996093750) + 765.432f == 16777981.428100586, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(make_fixed<31, 32>(16777215.996093750) + 765.432f), double>::value, "arithmetic operators test failed");
+static_assert(is_same<decltype(make_fixed<31, 32>(16777215.996093750) + 765.432f), double>::value, "arithmetic operators test failed");
 
 // subtraction
 static_assert(make_fixed<2, 5>(2.125) - make_fixed<2, 5>(3.25) == -1.125f, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(make_fixed<2, 5>(2.125) - make_fixed<2, 5>(-3.25)), make_fixed<2, 5>>::value, "arithmetic operators test failed");
-static_assert(fixed_point<std::uint8_t, 10>(10240) - 2048 == 8192, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(fixed_point<std::uint8_t, 10>(10240) - 2048), fixed_point<int, 0>>::value, "arithmetic operators test failed");
+static_assert(is_same<decltype(make_fixed<2, 5>(2.125) - make_fixed<2, 5>(-3.25)), make_fixed<2, 5>>::value, "arithmetic operators test failed");
+static_assert(fixed_point<uint8_t, 10>(10240) - 2048 == 8192, "arithmetic operators test failed");
+static_assert(is_same<decltype(fixed_point<uint8_t, 10>(10240) - 2048), fixed_point<int, 0>>::value, "arithmetic operators test failed");
 static_assert(765.432f - make_fixed<31, 32>(16777215.996093750) == -16776450.564086914, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(765.432f - make_fixed<31, 32>(16777215.996093750)), double>::value, "arithmetic operators test failed");
+static_assert(is_same<decltype(765.432f - make_fixed<31, 32>(16777215.996093750)), double>::value, "arithmetic operators test failed");
 
 // multiplication
 static_assert(make_fixed<2, 5>(2.125) * make_fixed<2, 5>(-1.75f) == -3.71875, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(make_fixed<2, 5>(2.125) * make_fixed<2, 5>(-3.25)), make_fixed<2, 5>>::value, "arithmetic operators test failed");
+static_assert(is_same<decltype(make_fixed<2, 5>(2.125) * make_fixed<2, 5>(-3.25)), make_fixed<2, 5>>::value, "arithmetic operators test failed");
 
-static_assert(fixed_point<std::uint8_t, 10>(10240) * 3u == 30720, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(fixed_point<std::uint8_t, 10>(10240) * 3u), fixed_point<std::uint8_t, 10>>::value, "arithmetic operators test failed");
-static_assert(3u * fixed_point<std::uint8_t, 10>(10240) == 30720, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(3u * fixed_point<std::uint8_t, 10>(10240)), fixed_point<std::uint8_t, 10>>::value, "arithmetic operators test failed");
+static_assert(fixed_point<uint8_t, 10>(10240) * 3u == 30720, "arithmetic operators test failed");
+static_assert(is_same<decltype(fixed_point<uint8_t, 10>(10240) * 3u), fixed_point<uint8_t, 10>>::value, "arithmetic operators test failed");
+static_assert(3u * fixed_point<uint8_t, 10>(10240) == 30720, "arithmetic operators test failed");
+static_assert(is_same<decltype(3u * fixed_point<uint8_t, 10>(10240)), fixed_point<uint8_t, 10>>::value, "arithmetic operators test failed");
 
 static_assert(-123.654f * make_fixed<31, 32>(16777215.996093750) == -2074569855.5169766, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(765.432f * make_fixed<31, 32>(16777215.996093750)), double>::value, "arithmetic operators test failed");
+static_assert(is_same<decltype(765.432f * make_fixed<31, 32>(16777215.996093750)), double>::value, "arithmetic operators test failed");
 static_assert(make_fixed<31, 32>(16777215.996093750) * -123.654f == -2074569855.5169766, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(make_fixed<31, 32>(16777215.996093750) * -123.654f), double>::value, "arithmetic operators test failed");
+static_assert(is_same<decltype(make_fixed<31, 32>(16777215.996093750) * -123.654f), double>::value, "arithmetic operators test failed");
 
 // division
 static_assert(make_fixed<2, 5>(2.5) / make_fixed<2, 5>(-4.f) == -.625, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(make_fixed<2, 5>(2.5) / make_fixed<2, 5>(-4.f)), make_fixed<2, 5>>::value, "arithmetic operators test failed");
+static_assert(is_same<decltype(make_fixed<2, 5>(2.5) / make_fixed<2, 5>(-4.f)), make_fixed<2, 5>>::value, "arithmetic operators test failed");
 
-static_assert(fixed_point<std::uint8_t, 10>(10240) / 3u == 3072, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(fixed_point<std::uint8_t, 10>(10240) / 3u), fixed_point<std::uint8_t, 10>>::value, "arithmetic operators test failed");
-static_assert(10 / fixed_point<std::uint8_t, -2>(0.25) == 40.L, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(10 / fixed_point<std::uint8_t, -2>(0.25)), fixed_point<std::uint8_t, -2>>::value, "arithmetic operators test failed");
+static_assert(fixed_point<uint8_t, 10>(10240) / 3u == 3072, "arithmetic operators test failed");
+static_assert(is_same<decltype(fixed_point<uint8_t, 10>(10240) / 3u), fixed_point<uint8_t, 10>>::value, "arithmetic operators test failed");
+static_assert(10 / fixed_point<uint8_t, -2>(0.25) == 40.L, "arithmetic operators test failed");
+static_assert(is_same<decltype(10 / fixed_point<uint8_t, -2>(0.25)), fixed_point<uint8_t, -2>>::value, "arithmetic operators test failed");
 
 static_assert(16777215.996093750 / make_fixed<31, 32>(-123.654f) == -135678.71712347874, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(16777215.996093750 / make_fixed<31, 32>(-123.654f)), double>::value, "arithmetic operators test failed");
+static_assert(is_same<decltype(16777215.996093750 / make_fixed<31, 32>(-123.654f)), double>::value, "arithmetic operators test failed");
 static_assert(make_fixed<31, 32>(16777215.996093750) / -123.654f == -135678.71712347874, "arithmetic operators test failed");
-static_assert(std::is_same<decltype(make_fixed<31, 32>(16777215.996093750) / -123.654f), double>::value, "arithmetic operators test failed");
+static_assert(is_same<decltype(make_fixed<31, 32>(16777215.996093750) / -123.654f), double>::value, "arithmetic operators test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::trunc_add_result_t
 
-static_assert(trunc_add_result_t<fixed_point<std::uint8_t, -4>>::integer_digits == 5, "sg14::trunc_add_result_t test failed");
-static_assert(trunc_add_result_t<fixed_point<std::int32_t, -25>, 4>::integer_digits == 8, "sg14::trunc_add_result_t test failed");
-static_assert(std::is_same<trunc_add_result_t<fixed_point<std::int8_t, 0>, 2>, fixed_point<int8_t, 1>>::value, "sg14::trunc_add_result_t test failed");
+static_assert(trunc_add_result_t<fixed_point<uint8_t, -4>>::integer_digits == 5, "sg14::trunc_add_result_t test failed");
+static_assert(trunc_add_result_t<fixed_point<int32_t, -25>, 4>::integer_digits == 8, "sg14::trunc_add_result_t test failed");
+static_assert(is_same<trunc_add_result_t<fixed_point<int8_t, 0>, 2>, fixed_point<int8_t, 1>>::value, "sg14::trunc_add_result_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::trunc_add
@@ -441,8 +442,8 @@ static_assert(trunc_add(make_fixed<7, 0>(-128), make_fixed<7, 0>(-128)) == -256,
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::trunc_subtract_result_t
 
-static_assert(std::is_same<trunc_subtract_result_t<make_ufixed<4, 4>>, make_fixed<5, 2>>::value, "sg14::trunc_subtract_result_t test failed");
-static_assert(std::is_same<trunc_subtract_result_t<make_fixed<4, 3>, make_ufixed<8, 8>>, make_fixed<9, 6>>::value, "sg14::trunc_subtract_result_t test failed");
+static_assert(is_same<trunc_subtract_result_t<make_ufixed<4, 4>>, make_fixed<5, 2>>::value, "sg14::trunc_subtract_result_t test failed");
+static_assert(is_same<trunc_subtract_result_t<make_fixed<4, 3>, make_ufixed<8, 8>>, make_fixed<9, 6>>::value, "sg14::trunc_subtract_result_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::trunc_subtract
@@ -458,9 +459,9 @@ static_assert(trunc_subtract(make_fixed<7, 0>(-128), make_fixed<7, 0>(127)) == -
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::trunc_multiply_result_t
 
-static_assert(trunc_multiply_result_t<fixed_point<std::uint8_t, -4>>::integer_digits == 8, "sg14::trunc_multiply_result_t test failed");
-static_assert(trunc_multiply_result_t<fixed_point<std::int32_t, -25>>::integer_digits == 12, "sg14::trunc_multiply_result_t test failed");
-static_assert(trunc_multiply_result_t<fixed_point<std::uint8_t, 0>>::integer_digits == 16, "sg14::trunc_multiply_result_t test failed");
+static_assert(trunc_multiply_result_t<fixed_point<uint8_t, -4>>::integer_digits == 8, "sg14::trunc_multiply_result_t test failed");
+static_assert(trunc_multiply_result_t<fixed_point<int32_t, -25>>::integer_digits == 12, "sg14::trunc_multiply_result_t test failed");
+static_assert(trunc_multiply_result_t<fixed_point<uint8_t, 0>>::integer_digits == 16, "sg14::trunc_multiply_result_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::trunc_multiply
@@ -478,11 +479,11 @@ static_assert(trunc_multiply(make_fixed<4, 3>(-16), make_fixed<4, 3>(-16)) == -2
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::trunc_divide_result_t
 
-static_assert(trunc_divide_result_t<fixed_point<std::uint8_t, -4>>::integer_digits == 8, "sg14::trunc_divide_result_t test failed");
+static_assert(trunc_divide_result_t<fixed_point<uint8_t, -4>>::integer_digits == 8, "sg14::trunc_divide_result_t test failed");
 static_assert(trunc_divide_result_t<make_fixed<4, 3>>::integer_digits == 7, "sg14::trunc_divide_result_t test failed");
-static_assert(trunc_divide_result_t<fixed_point<std::int32_t, -25>>::integer_digits == 31, "sg14::trunc_divide_result_t test failed");
-static_assert(trunc_divide_result_t<fixed_point<std::uint8_t, 0>>::integer_digits == 8, "sg14::trunc_divide_result_t test failed");
-static_assert(std::is_same<trunc_divide_result_t<make_fixed<15, 0>, make_fixed<7, 8>>, fixed_point<std::int16_t, 8>>::value, "sg14::trunc_divide_result_t test failed");
+static_assert(trunc_divide_result_t<fixed_point<int32_t, -25>>::integer_digits == 31, "sg14::trunc_divide_result_t test failed");
+static_assert(trunc_divide_result_t<fixed_point<uint8_t, 0>>::integer_digits == 8, "sg14::trunc_divide_result_t test failed");
+static_assert(is_same<trunc_divide_result_t<make_fixed<15, 0>, make_fixed<7, 8>>, fixed_point<int16_t, 8>>::value, "sg14::trunc_divide_result_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::trunc_divide
@@ -491,7 +492,7 @@ static_assert(trunc_divide(make_fixed<15, 0>(16129), make_fixed<15, 0>(127)) == 
 static_assert(trunc_divide(make_ufixed<8, 0>(240), make_ufixed<4, 4>(.9375)) == 256, "sg14::trunc_divide test failed");
 static_assert(trunc_divide(make_ufixed<4, 4>(0.0625), make_ufixed<4, 4>(0.0625)) == 1.f, "sg14::trunc_divide test failed");
 static_assert(trunc_divide(make_ufixed<8, 0>(0), make_ufixed<8, 0>(1)) == 0.f, "sg14::trunc_divide test failed");
-static_assert(trunc_divide(fixed_point<std::uint16_t, 0>(4096), make_ufixed<8, 0>(25)) == 163., "sg14::trunc_divide test failed");
+static_assert(trunc_divide(fixed_point<uint16_t, 0>(4096), make_ufixed<8, 0>(25)) == 163., "sg14::trunc_divide test failed");
 static_assert(trunc_divide(make_fixed<14, 0, false>(4288), make_fixed<6, 2, false>(25)) == 171, "sg14::trunc_divide test failed");
 static_assert((trunc_divide(make_fixed<20>(1040352), make_fixed<16, 0, false>(65535))) == 15.87451171875, "sg14::trunc_divide test failed");
 static_assert(trunc_divide(make_fixed<15>(254), make_fixed<4, 3>(-15.875)) == -16, "sg14::trunc_divide test failed");
@@ -499,8 +500,8 @@ static_assert(trunc_divide(make_fixed<15>(254), make_fixed<4, 3>(-15.875)) == -1
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::trunc_square_result_t
 
-static_assert(std::is_same<trunc_square_result_t<make_ufixed<4, 4>>, make_ufixed<8, 0>>::value, "sg14::trunc_square_result_t test failed");
-static_assert(std::is_same<trunc_square_result_t<make_fixed<6, 25>>, make_ufixed<12, 20>>::value, "sg14::trunc_square_result_t test failed");
+static_assert(is_same<trunc_square_result_t<make_ufixed<4, 4>>, make_ufixed<8, 0>>::value, "sg14::trunc_square_result_t test failed");
+static_assert(is_same<trunc_square_result_t<make_fixed<6, 25>>, make_ufixed<12, 20>>::value, "sg14::trunc_square_result_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::trunc_square
@@ -511,10 +512,10 @@ static_assert(trunc_square(make_ufixed<4, 4>(15.5)) == 240.f, "sg14::trunc_squar
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::trunc_sqrt_result_t
 
-static_assert(std::is_same<trunc_sqrt_result_t<make_ufixed<4, 4>>, make_ufixed<2, 6>>::value, "sg14::trunc_sqrt_result_t test failed");
+static_assert(is_same<trunc_sqrt_result_t<make_ufixed<4, 4>>, make_ufixed<2, 6>>::value, "sg14::trunc_sqrt_result_t test failed");
 static_assert(sizeof(trunc_sqrt_result_t<make_ufixed<4, 4>>) == sizeof(make_ufixed<2, 6>), "sg14::trunc_sqrt_result_t test failed");
 
-static_assert(std::is_same<trunc_sqrt_result_t<make_ufixed<15, 16>>, make_ufixed<8, 24>>::value, "sg14::trunc_sqrt_result_t test failed");
+static_assert(is_same<trunc_sqrt_result_t<make_ufixed<15, 16>>, make_ufixed<8, 24>>::value, "sg14::trunc_sqrt_result_t test failed");
 static_assert(sizeof(trunc_sqrt_result_t<make_ufixed<15, 16>>) == sizeof(make_ufixed<8, 24>), "sg14::trunc_sqrt_result_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -526,9 +527,9 @@ static_assert(trunc_sqrt(make_ufixed<8, 0>(240)) == 15.f, "sg14::trunc_sqrt test
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::promote_multiply_result_t
 
-static_assert(std::is_same<promote_multiply_result_t<make_ufixed<4, 4>>, make_ufixed<8, 8>>::value, "sg14::promote_multiply_result_t test failed");
-static_assert(std::is_same<promote_multiply_result_t<make_fixed<6, 25>>, make_fixed<13, 50>>::value, "sg14::promote_multiply_result_t test failed");
-static_assert(promote_multiply_result_t<fixed_point<std::uint8_t, 0>>::integer_digits == 16, "sg14::promote_multiply_result_t test failed");
+static_assert(is_same<promote_multiply_result_t<make_ufixed<4, 4>>, make_ufixed<8, 8>>::value, "sg14::promote_multiply_result_t test failed");
+static_assert(is_same<promote_multiply_result_t<make_fixed<6, 25>>, make_fixed<13, 50>>::value, "sg14::promote_multiply_result_t test failed");
+static_assert(promote_multiply_result_t<fixed_point<uint8_t, 0>>::integer_digits == 16, "sg14::promote_multiply_result_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::promote_multiply
@@ -546,8 +547,8 @@ static_assert(promote_multiply(make_fixed<4, 3>(-16), make_fixed<4, 3>(-16)) == 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::promote_square_result_t
 
-static_assert(std::is_same<promote_square_result_t<make_ufixed<4, 4>>, make_ufixed<8, 8>>::value, "sg14::promote_square_result_t test failed");
-static_assert(std::is_same<promote_square_result_t<make_fixed<6, 25>>, make_ufixed<12, 51>>::value, "sg14::promote_square_result_t test failed");
+static_assert(is_same<promote_square_result_t<make_ufixed<4, 4>>, make_ufixed<8, 8>>::value, "sg14::promote_square_result_t test failed");
+static_assert(is_same<promote_square_result_t<make_fixed<6, 25>>, make_ufixed<12, 51>>::value, "sg14::promote_square_result_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::promote_square

--- a/src/fixed_point_test.cpp
+++ b/src/fixed_point_test.cpp
@@ -476,6 +476,27 @@ static_assert(trunc_multiply(make_fixed<4, 3>(-16), make_fixed<4, 3>(-15.875)) =
 static_assert(trunc_multiply(make_fixed<4, 3>(-16), make_fixed<4, 3>(-16)) == -256, "sg14::trunc_multiply test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
+// sg14::trunc_divide_result_t
+
+static_assert(trunc_divide_result_t<fixed_point<std::uint8_t, -4>>::integer_digits == 8, "sg14::trunc_divide_result_t test failed");
+static_assert(trunc_divide_result_t<make_fixed<4, 3>>::integer_digits == 7, "sg14::trunc_divide_result_t test failed");
+static_assert(trunc_divide_result_t<fixed_point<std::int32_t, -25>>::integer_digits == 31, "sg14::trunc_divide_result_t test failed");
+static_assert(trunc_divide_result_t<fixed_point<std::uint8_t, 0>>::integer_digits == 8, "sg14::trunc_divide_result_t test failed");
+static_assert(std::is_same<trunc_divide_result_t<make_fixed<15, 0>, make_fixed<7, 8>>, fixed_point<std::int16_t, 8>>::value, "sg14::trunc_divide_result_t test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+// sg14::trunc_divide
+
+static_assert(trunc_divide(make_fixed<15, 0>(16129), make_fixed<15, 0>(127)) == 127, "sg14::trunc_divide test failed");
+static_assert(trunc_divide(make_ufixed<8, 0>(240), make_ufixed<4, 4>(.9375)) == 256, "sg14::trunc_divide test failed");
+static_assert(trunc_divide(make_ufixed<4, 4>(0.0625), make_ufixed<4, 4>(0.0625)) == 1.f, "sg14::trunc_divide test failed");
+static_assert(trunc_divide(make_ufixed<8, 0>(0), make_ufixed<8, 0>(1)) == 0.f, "sg14::trunc_divide test failed");
+static_assert(trunc_divide(fixed_point<std::uint16_t, 0>(4096), make_ufixed<8, 0>(25)) == 163., "sg14::trunc_divide test failed");
+static_assert(trunc_divide(make_fixed<14, 0, false>(4288), make_fixed<6, 2, false>(25)) == 171, "sg14::trunc_divide test failed");
+static_assert((trunc_divide(make_fixed<20>(1040352), make_fixed<16, 0, false>(65535))) == 15.87451171875, "sg14::trunc_divide test failed");
+static_assert(trunc_divide(make_fixed<15>(254), make_fixed<4, 3>(-15.875)) == -16, "sg14::trunc_divide test failed");
+
+////////////////////////////////////////////////////////////////////////////////
 // sg14::trunc_square_result_t
 
 static_assert(std::is_same<trunc_square_result_t<make_ufixed<4, 4>>, make_ufixed<8, 0>>::value, "sg14::trunc_square_result_t test failed");

--- a/src/fixed_point_test.cpp
+++ b/src/fixed_point_test.cpp
@@ -215,7 +215,7 @@ static_assert(fixed_point<uint64_t, -7>(232.125f) == 232.125L, "sg14::fixed_poin
 static_assert(fixed_point<int8_t, -7>(1) != 1.L, "sg14::fixed_point test failed");
 static_assert(fixed_point<int8_t, -7>(.5) == .5f, "sg14::fixed_point test failed");
 static_assert(fixed_point<int8_t, -7>(.125f) == .125L, "sg14::fixed_point test failed");
-static_assert(fixed_point<int16_t, -7>(123.125f) == 123, "sg14::fixed_point test failed");
+static_assert(fixed_point<int16_t, -7>(123.125f) != 123, "sg14::fixed_point test failed");
 static_assert(fixed_point<int32_t, -7>(123.125f) == 123.125, "sg14::fixed_point test failed");
 static_assert(fixed_point<int64_t, -7>(123.125l) == 123.125f, "sg14::fixed_point test failed");
 
@@ -316,8 +316,8 @@ static_assert(is_same<_impl::common_type<fixed_point<int16_t, 0>, fixed_point<ui
 // commonality between arithmetic and fixed_point types
 static_assert(is_same<_impl::common_type<float, fixed_point<int8_t, -4>>, float>::value, "sg14::_impl::common_type test failed");
 static_assert(is_same<_impl::common_type<double, fixed_point<int32_t, -14>>, double>::value, "sg14::_impl::common_type test failed");
-static_assert(is_same<_impl::common_type<int8_t, fixed_point<uint64_t, -60>>, fixed_point<int64_t, -56>>::value, "sg14::_impl::common_type test failed");
-static_assert(is_same<_impl::common_type<fixed_point<uint8_t, -4>, uint32_t>, fixed_point<uint32_t, 0>>::value, "sg14::_impl::common_type test failed");
+static_assert(is_same<_impl::common_type<int8_t, fixed_point<uint64_t, -60>>, fixed_point<uint64_t, -60>>::value, "sg14::_impl::common_type test failed");
+static_assert(is_same<_impl::common_type<fixed_point<uint8_t, -4>, uint32_t>, fixed_point<uint8_t, -4>>::value, "sg14::_impl::common_type test failed");
 static_assert(is_same<_impl::common_type<fixed_point<int16_t, -4>, float>, float>::value, "sg14::_impl::common_type test failed");
 static_assert(is_same<_impl::common_type<fixed_point<int16_t, 0>, double>, double>::value, "sg14::_impl::common_type test failed");
 
@@ -380,20 +380,22 @@ static_assert(make_fixed<2, 5>(2.125) + make_fixed<2, 5>(-3.25) == -1.125f, "ari
 static_assert(is_same<decltype(make_fixed<2, 5>(2.125) + make_fixed<2, 5>(-3.25)), make_fixed<2, 5>>::value, "arithmetic operators test failed");
 
 static_assert(fixed_point<uint8_t, 10>(10240) + 2048 == 12288, "arithmetic operators test failed");
-static_assert(is_same<decltype(fixed_point<uint8_t, 10>(10240) + 2048), fixed_point<int, 0>>::value, "arithmetic operators test failed");
+static_assert(is_same<decltype(fixed_point<uint8_t, 10>(10240) + 2048), fixed_point<uint8_t, 10>>::value, "arithmetic operators test failed");
 static_assert(2048 + fixed_point<uint8_t, 10>(10240) == 12288, "arithmetic operators test failed");
-static_assert(is_same<decltype(2048 + fixed_point<uint8_t, 10>(10240)), fixed_point<int, 0>>::value, "arithmetic operators test failed");
+static_assert(is_same<decltype(2048 + fixed_point<uint8_t, 10>(10240)), fixed_point<uint8_t, 10>>::value, "arithmetic operators test failed");
 
 static_assert(765.432f + make_fixed<31, 32>(16777215.996093750) == 16777981.428100586, "arithmetic operators test failed");
 static_assert(is_same<decltype(765.432f + make_fixed<31, 32>(16777215.996093750)), double>::value, "arithmetic operators test failed");
 static_assert(make_fixed<31, 32>(16777215.996093750) + 765.432f == 16777981.428100586, "arithmetic operators test failed");
 static_assert(is_same<decltype(make_fixed<31, 32>(16777215.996093750) + 765.432f), double>::value, "arithmetic operators test failed");
 
+static_assert(fixed_point<int32_t,-16>(.5) + 2 == 2.5, "arithmetic operators test failed");
+
 // subtraction
 static_assert(make_fixed<2, 5>(2.125) - make_fixed<2, 5>(3.25) == -1.125f, "arithmetic operators test failed");
 static_assert(is_same<decltype(make_fixed<2, 5>(2.125) - make_fixed<2, 5>(-3.25)), make_fixed<2, 5>>::value, "arithmetic operators test failed");
 static_assert(fixed_point<uint8_t, 10>(10240) - 2048 == 8192, "arithmetic operators test failed");
-static_assert(is_same<decltype(fixed_point<uint8_t, 10>(10240) - 2048), fixed_point<int, 0>>::value, "arithmetic operators test failed");
+static_assert(is_same<decltype(fixed_point<uint8_t, 10>(10240) - 2048), fixed_point<uint8_t, 10>>::value, "arithmetic operators test failed");
 static_assert(765.432f - make_fixed<31, 32>(16777215.996093750) == -16776450.564086914, "arithmetic operators test failed");
 static_assert(is_same<decltype(765.432f - make_fixed<31, 32>(16777215.996093750)), double>::value, "arithmetic operators test failed");
 
@@ -521,7 +523,7 @@ static_assert(sizeof(trunc_sqrt_result_t<make_ufixed<15, 16>>) == sizeof(make_uf
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::trunc_sqrt
 
-static_assert(trunc_sqrt(make_fixed<14, 1>(16128)) == 126, "sg14::trunc_sqrt test failed");
+static_assert(trunc_sqrt(make_fixed<14, 1>(16128)) == 126.5, "sg14::trunc_sqrt test failed");
 static_assert(trunc_sqrt(make_ufixed<8, 0>(240)) == 15.f, "sg14::trunc_sqrt test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -535,7 +537,7 @@ static_assert(promote_multiply_result_t<fixed_point<uint8_t, 0>>::integer_digits
 // sg14::promote_multiply
 
 static_assert(promote_multiply(make_fixed<7, 8>(127), make_fixed<7, 8>(127)) == 16129, "sg14::promote_multiply test failed");
-static_assert(promote_multiply(make_ufixed<4, 4>(15.9375), make_ufixed<4, 4>(15.9375)) == 254, "sg14::promote_multiply test failed");
+static_assert(promote_multiply(make_ufixed<4, 4>(15.9375), make_ufixed<4, 4>(15.9375)) == 254.00390625, "sg14::promote_multiply test failed");
 static_assert(promote_multiply(make_ufixed<4, 4>(0.0625), make_ufixed<4, 4>(0.0625)) == 0.00390625f, "sg14::promote_multiply test failed");
 static_assert(promote_multiply(make_ufixed<8, 0>(1), make_ufixed<8, 0>(1)) == 1.f, "sg14::promote_multiply test failed");
 static_assert(promote_multiply(make_ufixed<8, 0>(174), make_ufixed<8, 0>(25)) == 4350.f, "sg14::promote_multiply test failed");
@@ -555,7 +557,7 @@ static_assert(is_same<promote_square_result_t<make_fixed<6, 25>>, make_ufixed<12
 
 static_assert(promote_square(make_ufixed<7, 1>(127.5)) == 16256.25f, "sg14::promote_square test failed");
 static_assert(promote_square(make_ufixed<4, 4>(15.5)) == 240.25f, "sg14::promote_square test failed");
-static_assert(promote_square(make_fixed<31>(2000000000)) == 4000000000000000000ULL, "sg14::promote_square test failed");
+static_assert(static_cast<uint64_t>(promote_square(make_fixed<31>(2000000000))) == 4000000000000000000ULL, "sg14::promote_square test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::sqrt

--- a/src/proposal_test.cpp
+++ b/src/proposal_test.cpp
@@ -47,9 +47,13 @@ void proposal_test()
 	static_assert(make_fixed<7, 0>(15) / make_fixed<7, 0>(2) == 7.f, "Incorrect information in proposal section, Underflow");
 
 	// Type Promotion
-	auto type_promotion = promote(make_fixed<5, 2>(15.5));
-	static_assert(is_same<decltype(type_promotion), make_fixed<11, 4>>::value, "Incorrect information in proposal section, Type Promotion and Demotion Functions");
+	auto unpromoted_type = make_fixed<5, 2>(15.5);
+	auto type_promotion = promote(unpromoted_type);
+	static_assert(is_same<decltype(type_promotion), make_fixed<11, 4>>::value, "Incorrect information in proposal section, Type Promotion");
 	ASSERT_EQUAL(type_promotion, 15.5f);
+
+	auto type_demotion = demote(type_promotion);
+	static_assert(is_same<decltype(type_demotion), decltype(unpromoted_type)>::value, "Incorrect information in proposal section, Type Promotion");
 
 	// Named Arithmetic Functions
 	auto sq = trunc_multiply(make_ufixed<4, 4>(15.9375), make_ufixed<4, 4>(15.9375));

--- a/src/proposal_test.cpp
+++ b/src/proposal_test.cpp
@@ -41,7 +41,7 @@ void proposal_test()
 	ASSERT_EQUAL(conversion_lhs, conversion_rhs);
 
 	// Arithmetic Operators (Overflow)
-	static_assert(make_fixed<4, 3>(15) + make_fixed<4, 3>(1) != 16, "Incorrect information in proposal section, Overflow");
+	static_assert(static_cast<int>(make_fixed<4, 3>(15) + make_fixed<4, 3>(1)) != 16, "Incorrect information in proposal section, Overflow");
 
 	// Arithmetic Operators (Underflow)
 	static_assert(make_fixed<7, 0>(15) / make_fixed<7, 0>(2) == 7.f, "Incorrect information in proposal section, Underflow");
@@ -67,7 +67,7 @@ void proposal_test()
 	ASSERT_EQUAL(square, 0);
 
 	// Underflow
-	static_assert(trunc_square(make_ufixed<8, 0>(15)) != 15 * 15, "wrong behavior reported in 'Overflow and Underflow' section");
+	static_assert(static_cast<int>(trunc_square(make_ufixed<8, 0>(15))) != 15 * 15, "wrong behavior reported in 'Overflow and Underflow' section");
 
 	// Examples
 	static_assert(magnitude(


### PR DESCRIPTION
Mixed-type between fixed-type and integer now simply uses the fixed-type. Otherwise, necessary precision can be wiped out. Example provided by Ryhor [here](https://groups.google.com/a/isocpp.org/forum/?utm_medium=email&utm_source=footer#!msg/sg14/1w5eiJsyT2Q/vlBvE-2uAwAJ):

```
fixed_point<int32_t,-16>(.5)+2
```
