### PR TITLE
Factory functions

### DIFF
--- a/doc/p0037.md
+++ b/doc/p0037.md
@@ -146,7 +146,7 @@ and
 
 They resolve to a `fixed_point` specialization with the given
 signedness and number of integer and fractional digits. They may
-contain additional integer and fractional digits.
+contain additional integer digits.
 
 For example, one could define and initialize an 8-bit, unsigned,
 fixed-point variable with four integer digits and four fractional

--- a/doc/p0037.md
+++ b/doc/p0037.md
@@ -480,8 +480,6 @@ returns the value, 9.890625.
         using make_fixed;
       template <int IntegerDigits, int FractionalDigits = 0, class Archetype = unsigned>
         using make_ufixed;
-      template <class ReprType, int IntegerDigits>
-        using make_fixed_from_repr;
 
 	  template <class ReprType, int Exponent, int NumBytes>
 	    struct resize<fixed_point<ReprType, Exponent>, NumBytes>;

--- a/doc/p0037.md
+++ b/doc/p0037.md
@@ -451,23 +451,28 @@ and the type of `resize_t<int8_t, 8>` is `int64_t`.
 
 ### Example
 
-The following example calculates the magnitude of a 3-dimensional vector.
+The following function, `magnitude`, calculates the magnitude of a 3-dimensional vector.
 
-    template <class Fp>
-    constexpr auto magnitude(const Fp & x, const Fp & y, const Fp & z)
-    -> decltype(trunc_sqrt(trunc_add(trunc_square(x), trunc_square(y), trunc_square(z))))
-    {
-        return trunc_sqrt(trunc_add(trunc_square(x), trunc_square(y), trunc_square(z)));
-    }
+``` c++
+template<class Fp>
+constexpr auto magnitude(Fp x, Fp y, Fp z)
+{
+    return sqrt(x*x+y*y+z*z);
+}
+```
 
-Calling the above function as follows
+And here is a call to `magnitude`.
 
-    static_cast<double>(magnitude(
+``` c++
+auto m = magnitude(
         make_ufixed<4, 12>(1),
         make_ufixed<4, 12>(4),
-        make_ufixed<4, 12>(9)));
+        make_ufixed<4, 12>(9));
+// m === make_fixed<19, 12>(9.8994140625)
+```
 
-returns the value, 9.890625.
+Observe that the arithmetic operations in `magnitude` obey the promotion rules of their underlying type.
+Hence `m` is backed by `int` - which is 32 bits wide on most modern architectures.
 
 ## V. Technical Specification
 
@@ -613,50 +618,6 @@ returns the value, 9.890625.
       template <class ReprType, int Exponent>
       	constexpr fixed_point<ReprType, Exponent>
       	  sqrt(const fixed_point<ReprType, Exponent> & x) noexcept;
-      template <class FixedPoint, unsigned N = 2>
-      	using trunc_add_result;
-
-      template <class FixedPoint, class ... Tail>
-      	trunc_add_result<FixedPoint, sizeof...(Tail) + 1>
-          constexpr trunc_add(const FixedPoint & addend1, const Tail & ... addend_tail);
-      template <class Lhs, class Rhs = Lhs>
-      	using trunc_subtract_result;
-      template <class Lhs, class Rhs>
-      	trunc_subtract_result<Lhs, Rhs>
-      	  constexpr trunc_subtract(const Lhs & minuend, const Rhs & subtrahend);
-      template <class Lhs, class Rhs = Lhs>
-      	using trunc_multiply_result;
-
-      template <class Lhs, class Rhs>
-      	trunc_multiply_result<Lhs, Rhs>
-      	  constexpr trunc_multiply(const Lhs & lhs, const Rhs & rhs) noexcept;
-      template <class FixedPointDividend, class FixedPointDivisor = FixedPointDividend>
-      	using trunc_divide_result;
-      template <class FixedPointDividend, class FixedPointDivisor>
-      	trunc_divide_result<FixedPointDividend, FixedPointDivisor>
-      	  constexpr trunc_divide(const FixedPointDividend & lhs, const FixedPointDivisor & rhs) noexcept;
-      template <class FixedPoint>
-      	using trunc_reciprocal_result;
-      template <class FixedPoint>
-      	trunc_reciprocal_result<FixedPoint>
-      	  constexpr trunc_reciprocal(const FixedPoint & fixed_point) noexcept;
-      template <class FixedPoint>
-      	using trunc_square_result;
-
-      template <class FixedPoint>
-      	trunc_square_result<FixedPoint>
-      	  constexpr trunc_square(const FixedPoint & root) noexcept;
-      template <class FixedPoint>
-      	using trunc_sqrt_result;
-      template <class FixedPoint>
-      	trunc_sqrt_result<FixedPoint>
-      	  constexpr trunc_sqrt(const FixedPoint & square) noexcept;
-      template <int Integer, class ReprType, int Exponent>
-      	constexpr fixed_point<ReprType, Exponent + Integer>
-      	  trunc_shift_left(const fixed_point<ReprType, Exponent> & fp) noexcept;
-      template <int Integer, class ReprType, int Exponent>
-      	constexpr fixed_point<ReprType, Exponent - Integer>
-      	  trunc_shift_right(const fixed_point<ReprType, Exponent> & fp) noexcept;
 
       template <class Archetype, int NumBytes>
 	    struct resize;

--- a/doc/p0037.md
+++ b/doc/p0037.md
@@ -871,7 +871,10 @@ Items include:
 * utility header containing definitions for:
   * math and trigonometric functions and
   * a partial `numeric_limits` specialization;
-* a type, `sg14::integer`, intended to explore and illustrate the potential of custom `ReprType`;
+* a type, `integer`, intended to explore and illustrate the potential of custom `ReprType`;
+* a type, `elastic`, intended to illustrate the use of `fixed_point` 
+  to design better-behaved numeric types such as those presented in 
+  P0106 [\[8\]](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0106r0.html);
 * compile-time tests of `constexpr` operations;
 * run-time tests of assignment and exception-throwing behavior and
 * benchmarking support (used to generate results in this paper).

--- a/doc/p0037.md
+++ b/doc/p0037.md
@@ -699,34 +699,6 @@ prevents a function from being defined as pure. This highlights a
 wider issue surrounding the adoption of the functional approach and
 compile-time computation that is beyond the scope of this document.
 
-### Bounded Integers
-
-The bounded::integer library [\[3\]](http://doublewise.net/c++/bounded/)
-exemplifies the benefits of keeping track of ranges of values in
-arithmetic types at compile time.
-
-To a limited extent, the `trunc_` functions defined here also keep
-track of - and modify - the limits of values. However, a combination
-of techniques is capable of producing superior results.
-
-For instance, consider the following expression:
-
-    make_ufixed<2, 6> three(3);
-    auto n = trunc_square(trunc_square(three));
-
-The type of `n` is `make_ufixed<8, 0>` but its value does not
-exceed 81. Hence, an integer bit has been wasted. It may be possible
-to track more accurate limits in the same manner as the
-bounded::integer library in order to improve the precision of types
-returned by `trunc_` functions. For this reason, the exact value of
-the exponents of these return types is not given.
-
-Notes:
-* Bounded::integer is already supported by fixed-point library,
-*fp* [\[4\]](https://github.com/mizvekov/fp).
-* A similar library is the boost *constrained_value* library
-[\[5\]](http://rk.hekko.pl/constrained_value/).
-
 ### Compile-Time Bit-Shift Operations
 
 A notable feature of the *fp* library [\[4\]](https://github.com/mizvekov/fp)
@@ -747,7 +719,7 @@ but it is by no means the only viable one.
 The *fp* library [\[4\]](https://github.com/mizvekov/fp) returns a type 
 whose size matches the inputs but whose exponent is shifted to preserve high bits. 
 The arithmetic types proposed in P0106 
-[\[9\]](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0106r0.html)
+[\[8\]](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0106r0.html)
 increase capacity to ensure that precision is preserved.
 Even greater control of the required capacity of a fixed-point type can be afforded by
 systems such as the *bounded::integer* library [\[3\]](http://doublewise.net/c++/bounded/).
@@ -776,7 +748,7 @@ a continuous range of exponents through type parameterization.
 ### N1169
 
 One example of the former is found in proposal N1169
-[\[6\]](http://www.open-std.org/JTC1/SC22/WG14/www/docs/n1169.pdf),
+[\[5\]](http://www.open-std.org/JTC1/SC22/WG14/www/docs/n1169.pdf),
 the intent of which is to expose features found in certain embedded
 hardware. It introduces a succinct set of language-level fixed-point
 types and impose constraints on the number of integer or fractional
@@ -797,9 +769,9 @@ fixed-point arithmetic at the hardware level.
 There are many other C++ libraries available which fall into the
 latter category of continuous-range fixed-point arithmetic
 [\[4\]](https://github.com/mizvekov/fp)
-[\[7\]](http://www.codeproject.com/Articles/37636/Fixed-Point-Class)
-[\[8\]](https://github.com/viboes/fixed_point). In particular, an
-existing library proposal, P0106 [\[9\]](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0106r0.html),
+[\[6\]](http://www.codeproject.com/Articles/37636/Fixed-Point-Class)
+[\[7\]](https://github.com/viboes/fixed_point). In particular, an
+existing library proposal, P0106 [\[8\]](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0106r0.html),
 aims to achieve very similar goals through similar means and warrants
 closer comparison than N1169.
 
@@ -882,7 +854,6 @@ This paper revises [P0037R0](http://johnmcfarlane.github.io/fixed_point/papers/p
 1. Rounding and Overflow in C++, <http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0105r0.html>
 1. C++ bounded::integer library, <http://doublewise.net/c++/bounded/>
 1. fp, C++14 Fixed Point Library, <https://github.com/mizvekov/fp>
-1. Boost Constrained Value Libarary, <http://rk.hekko.pl/constrained_value/>
 1. N1169, Extensions to support embedded processors, <http://www.open-std.org/JTC1/SC22/WG14/www/docs/n1169.pdf>
 1. fpmath, Fixed Point Math Library, <http://www.codeproject.com/Articles/37636/Fixed-Point-Class>
 1. Boost fixed_point (proposed), Fixed point integral and fractional types, <https://github.com/viboes/fixed_point>
@@ -893,7 +864,7 @@ This paper revises [P0037R0](http://johnmcfarlane.github.io/fixed_point/papers/p
 
 An in-development implementation of the fixed_point class template and
 its essential supporting functions and types is available
-[\[10\]](https://github.com/johnmcfarlane/fixed_point). 
+[\[9\]](https://github.com/johnmcfarlane/fixed_point). 
 
 Items include:
 

--- a/include/fixed_point.h
+++ b/include/fixed_point.h
@@ -525,16 +525,6 @@ namespace sg14 {
             FractionalDigits,
             typename std::make_unsigned<Archetype>::type>;
 
-    ////////////////////////////////////////////////////////////////////////////////
-    // sg14::make_fixed_from_repr
-
-    // yields a fixed_point with Exponent calculated such that
-    // fixed_point<ReprType, Exponent>::integer_bits == IntegerDigits
-    template<class ReprType, int IntegerDigits>
-    using make_fixed_from_repr = fixed_point<
-            ReprType,
-            IntegerDigits+std::is_signed<ReprType>::value-(signed) sizeof(ReprType)*CHAR_BIT>;
-
     /// produces equivalent fixed-point type at a new size
     ///
     /// \tparam ReprType the \a ReprType parameter of @ref fixed_point

--- a/include/fixed_point.h
+++ b/include/fixed_point.h
@@ -492,7 +492,7 @@ namespace sg14 {
     /// \brief Produce a fixed-point type with the given number of integer and fractional digits.
     ///
     /// \tparam IntegerDigits specifies minimum value of @ref fixed_point::integer_digits
-    /// \tparam FractionalDigits specifies minimum value of @ref fixed_point::fractional_digits
+    /// \tparam FractionalDigits specifies the exact value of @ref fixed_point::fractional_digits
     /// \tparam Archetype hints at the type of @ref fixed_point::repr_type
     ///
     /// \remarks The signage of \a Archetype specifies signage of the resultant fixed-point type.
@@ -502,19 +502,14 @@ namespace sg14 {
     ///
     /// \par Example:
     ///
-    /// To generate a 2-byte fixed-point type with a sign bit, 7 integer bits and 8 fractional bits:
+    /// To generate a fixed-point type with a sign bit, 8 fractional bits and at least 7 integer bits:
     /// \snippet snippets.cpp use make_fixed
     ///
     /// \sa make_ufixed
     template<int IntegerDigits, int FractionalDigits = 0, class Archetype = signed>
     using make_fixed = fixed_point<
             _fixed_point_impl::sufficient_repr<IntegerDigits+FractionalDigits+std::is_signed<Archetype>::value, Archetype>,
-            int(IntegerDigits)
-                    +int(std::is_signed<Archetype>::value)
-                    -_fixed_point_impl::num_bits<
-                            _fixed_point_impl::sufficient_repr<
-                                    IntegerDigits+FractionalDigits+int(std::is_signed<Archetype>::value),
-                                    Archetype>>()>;
+            -FractionalDigits>;
 
     /// \brief Produce an unsigned fixed-point type with the given number of integer and fractional digits.
     ///

--- a/src/test/fixed_point_common.h
+++ b/src/test/fixed_point_common.h
@@ -48,9 +48,6 @@ using fixed_point = sg14::fixed_point<ReprType, Exponent>;
 template<int IntegerDigits, int FractionalDigits = 0, class Archetype = test_signed>
 using make_fixed = sg14::make_fixed<IntegerDigits, FractionalDigits, Archetype>;
 
-template<class ReprType, int IntegerDigits>
-using make_fixed_from_repr = sg14::make_fixed_from_repr<ReprType, IntegerDigits>;
-
 template<int IntegerDigits, int FractionalDigits = 0, class Archetype = test_unsigned>
 using make_ufixed = sg14::make_ufixed<IntegerDigits, FractionalDigits, Archetype>;
 
@@ -442,12 +439,6 @@ static_assert(
                         fixed_point<uint8, -4>>::result_type,
                 fixed_point<decltype(std::declval<uint8>() + std::declval<uint8>()), -3>>::value,
         "sg14::_impl::default_arithmtic_policy test failed");
-
-////////////////////////////////////////////////////////////////////////////////
-// sg14::make_fixed_from_repr
-
-static_assert(make_fixed_from_repr<uint8, 8>::integer_digits==8, "sg14::make_fixed_from_repr test failed");
-static_assert(make_fixed_from_repr<int32, 27>::integer_digits==27, "sg14::make_fixed_from_repr test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::resize_t

--- a/src/test/proposal.cpp
+++ b/src/test/proposal.cpp
@@ -12,6 +12,7 @@ using sg14::fixed_point;
 using sg14::make_fixed;
 using sg14::make_ufixed;
 using sg14::multiply;
+using sg14::sqrt;
 using std::is_same;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -95,6 +96,24 @@ TEST(proposal, named_arithmetic3)
 
     static_assert(is_same<decltype(p), make_fixed<27, 4>>::value, "Incorrect formation in proposal section, Named Arithmetic Functions");
     ASSERT_EQ(p, 254.00000000);
+}
+
+// Examples
+template<class Fp>
+constexpr auto magnitude(Fp x, Fp y, Fp z)
+-> decltype(sqrt(x*x+y*y+z*z))
+{
+    return sqrt(x*x+y*y+z*z);
+}
+
+TEST(proposal, examples)
+{
+    auto m = magnitude(
+            make_ufixed<4, 12>(1),
+            make_ufixed<4, 12>(4),
+            make_ufixed<4, 12>(9));
+    static_assert(is_same<decltype(m), make_fixed<19, 12>>::value, "Incorrect formation in proposal section, Examples");
+    ASSERT_EQ(m, 9.8994140625);
 }
 
 TEST(proposal, zero)


### PR DESCRIPTION
Most importantly updates `make_fixed` and `make_ufixed` to they don't give extra digits to fractional component. 
