### PR TITLE
Rep

### DIFF
--- a/doc/elastic.md
+++ b/doc/elastic.md
@@ -107,18 +107,18 @@ using custom_integer = overflow_integer<Covf, rounding_integer<Crnd, sized_integ
 ### The `fixed_point` Class Template
 
 This class template is described in detail in [P0037](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0037r1.html).
-It stores an integer of type, `ReprType`, which is left-shifted by fixed amount, `Exponent`, 
+It stores an integer of type, `Rep`, which is left-shifted by fixed amount, `Exponent`, 
 to produce an approximation of a real number.
 
 ```
-template <typename ReprType = int, int Exponent = 0>
+template <typename Rep = int, int Exponent = 0>
 class fixed_point;
 ```
 
 The intention is to treat integers as the sub-set of fixed-point numbers that have exponent, zero.
 As far as practically possible, `fixed_point<T, 0>` should be interchangeable with `T`.
 
-While the most obvious choices for `ReprType` are built-in integers, any integer-like type is acceptable.
+While the most obvious choices for `Rep` are built-in integers, any integer-like type is acceptable.
 The `custom_integer` type described above is an ideal candidate 
 and illustrates how `fixed_point` is designed to be extensible.
 For example, a u16.16 fixed-point type with high-fidelity rounding characteristics might be expressed as:

--- a/doc/p0037.md
+++ b/doc/p0037.md
@@ -648,7 +648,7 @@ Hence `m` is backed by `int` - which is 32 bits wide on most modern architecture
     class fixed_point
     {
     public:
-      using repr_type = Rep;
+      using rep = Rep;
 
       constexpr static int exponent;
       constexpr static int digits;
@@ -680,8 +680,8 @@ Hence `m` is backed by `int` - which is 32 bits wide on most modern architecture
       template <class Rhs, typename std::enable_if<std::is_arithmetic<Rhs>::value, int>::type Dummy = 0>
         fixed_point & operator/=(const Rhs & rhs) noexcept;
 
-      constexpr repr_type data() const noexcept;
-      static constexpr fixed_point from_data(repr_type r) noexcept;
+      constexpr rep data() const noexcept;
+      static constexpr fixed_point from_data(rep r) noexcept;
     };
 
 ### Header \<type_traits\> Synopsis

--- a/doc/p0037.md
+++ b/doc/p0037.md
@@ -386,12 +386,12 @@ A composable system of integer types that is suitable for use with `fixed_point`
     template <int NumBytes, bool IsSigned = true>
     class sized_integer;
 
-    // may take built-in or sized_integer as Repr parameter
-    template <class Repr = int, rounding Rounding = rounding::towards_odd>
+    // may take built-in or sized_integer as Rep parameter
+    template <class Rep = int, rounding Rounding = rounding::towards_odd>
     class rounding_integer;
     
-    // may take built-in, sized_integer or rounding_integer as Repr parameter
-    template <class Repr = int, overflow Overflow = overflow::exception>
+    // may take built-in, sized_integer or rounding_integer as Rep parameter
+    template <class Rep = int, overflow Overflow = overflow::exception>
     class overflow_integer;
     
     // a 'kitchen sink' custom integer type  

--- a/doc/p0037.md
+++ b/doc/p0037.md
@@ -70,20 +70,20 @@ are deferred to the underlying integer types used as storage.
 
 Fixed-point numbers are specializations of
 
-    template <class ReprType, int Exponent>
+    template <class Rep, int Exponent>
     class fixed_point;
 
 where the template parameters are described as follows.
 
-#### `ReprType` Type Template Parameter
+#### `Rep` Type Template Parameter
 
 This parameter identifies the capacity and signedness of the
 underlying type used to represent the value. In other words, the size
-of the resulting type will be `sizeof(ReprType)` and it will be
-signed iff `is_signed<ReprType>::value` is true. The default is
+of the resulting type will be `sizeof(Rep)` and it will be
+signed iff `is_signed<Rep>::value` is true. The default is
 `int`.
 
-`ReprType` may be a fundamental integral type or similar type with bit-shift and arithmetic operators.
+`Rep` may be a fundamental integral type or similar type with bit-shift and arithmetic operators.
 The most suitable types are: `std::int8_t`, `std::uint8_t`,
 `std::int16_t`, `std::uint16_t`, `std::int32_t` and `std::uint32_t`.
 In limited situations, `std::int64_t` and `std::uint64_t` can be used.
@@ -105,11 +105,11 @@ The resolution of a specialization of `fixed_point` is
 
 and the minimum and maximum values are
 
-    std::numeric_limits<ReprType>::min() * pow(2, Exponent)
+    std::numeric_limits<Rep>::min() * pow(2, Exponent)
 
 and
 
-    std::numeric_limits<ReprType>::max() * pow(2, Exponent)
+    std::numeric_limits<Rep>::max() * pow(2, Exponent)
 
 respectively.
 
@@ -160,7 +160,7 @@ fractional digits:
     make_fixed<2, 29> value { 3.141592653 };
 
 Type parameter, `Archetype`, is provided in the case that a
-`fixed_point` specialization is desired which has as the `ReprType`
+`fixed_point` specialization is desired which has as the `Rep`
 parameter some type other than a built-in integral. The signedness of 
 `Archetype` corresponds to the signedness of the resultant 
 `fixed_point` specialization although the size does not.
@@ -172,7 +172,7 @@ arithmetic types.
 
 While effort is made to ensure that significant digits are not lost
 during conversion, no effort is made to avoid rounding errors.
-Whatever would happen when converting to and from `ReprType` largely 
+Whatever would happen when converting to and from `Rep` largely 
 applies to `fixed_point` objects also. For example:
 
     make_ufixed<4, 4>(.006) == make_ufixed<4, 4>(0)
@@ -197,13 +197,13 @@ Where the inputs are not identical fixed-point types, a simple set of
 promotion-like rules are applied to determine the return type:
 
 1. If both arguments are fixed-point, 
-   then the result has a `ReprType` which is the common type of the `ReprType` of the inputs
+   then the result has a `Rep` which is the common type of the `Rep` of the inputs
    and the `Exponent` value of the input with the greater integer capacity.
 2. If one of the arguments is a floating-point type, then the type of
    the result is the smallest floating-point type of equal or greater
    size than the inputs.
 3. If one of the arguments is an integral type, 
-   then the result has a `ReprType` which is the common type of the input fixed-point `ReprType` and the integral type 
+   then the result has a `Rep` which is the common type of the input fixed-point `Rep` and the integral type 
    and the same `Exponent` value as the input fixed-point type.
 
 Some examples:
@@ -226,7 +226,7 @@ and performance. It is explained for each rule as follows:
 3. preserves the input fixed-point type whose range is far more likely
    to be of deliberate importance to the operation.
 
-A guiding aim is for specializations with `Exponent` set to 0 to behave as closely as possible like their `ReprType`.
+A guiding aim is for specializations with `Exponent` set to 0 to behave as closely as possible like their `Rep`.
 For instance, where possible, an object of type, `int`, should be interchangeable with `fixed_point<>`.
 
 Shift operator overloads require an integer type as the right-hand
@@ -248,7 +248,7 @@ is zero on architectures where `int` is 4 bytes because a type with 2 integer bi
 store a value of 4.
 
 The result of overflow of any bits in a fixed-point value depends 
-entirely on how `ReprType` handles overflow. Thus, for built-in 
+entirely on how `Rep` handles overflow. Thus, for built-in 
 signed types, the result is undefined and for built-in unsigned types,
 the value wraps around.
 
@@ -263,7 +263,7 @@ generally considered acceptable.
 
 However, when all bits are lost due to underflow, the value is said
 to be flushed. As with overflow, the result of a flush is the same for
-a fixed-point type as it is for its underlying `ReprType`. In the case
+a fixed-point type as it is for its underlying `Rep`. In the case
 of built-in integral types, the value becomes zero.
 
 ### Dealing With Overflow and Flushes
@@ -278,7 +278,7 @@ Four strategies for avoiding overflow in fixed-point types are
 presented:
 
 1. simply leave it to the user to avoid overflow;
-1. allow the user to provide a custom type for `ReprType` 
+1. allow the user to provide a custom type for `Rep` 
    which behaves differently from built-in integral types;
 1. promote the result to a larger type to ensure sufficient capacity
    or
@@ -293,7 +293,7 @@ about in code where functions are written with a particular type in
 mind. It also requires the least computation in most cases.
 
 Choice 2) is beyond the scope of this proposal
-and is covered in more detail in the section, **Alternative Types for `ReprType`**.
+and is covered in more detail in the section, **Alternative Types for `Rep`**.
 
 Choices 3) and 4) are reasonably robust to overflow events. 
 However, they represent different trade-offs and neither one is the best fit in all situations. 
@@ -351,7 +351,7 @@ auto p = f * f;
 // p === make_fixed<27, 4>>{254.00000000}
 ```
 
-### Alternative Types for `ReprType`
+### Alternative Types for `Rep`
 
 Using built-in integral types as the default underlying representation
 minimizes certain costs:
@@ -413,7 +413,7 @@ to attempt to address rounding and error handling at the level of a fixed-point 
 
 #### Required Specializations
 
-For a type to be suitable as parameter, `ReprType`, of `fixed_point`,
+For a type to be suitable as parameter, `Rep`, of `fixed_point`,
 it must meet the following requirements:
 
 * it must have specialized the following existing standard library types:
@@ -424,7 +424,7 @@ it must meet the following requirements:
 
 #### The `width` Helper Type
 
-Any type used as `ReprType` (including built-in integers) must have defined specializations of `width`:
+Any type used as `Rep` (including built-in integers) must have defined specializations of `width`:
 ``` c++
 template <class T>
 struct width;
@@ -496,68 +496,68 @@ Hence `m` is backed by `int` - which is 32 bits wide on most modern architecture
 ### Header \<fixed_point\> Synopsis
 
     namespace std {
-      template <class ReprType, int Exponent> class fixed_point;
+      template <class Rep, int Exponent> class fixed_point;
 
       template <int IntegerDigits, int FractionalDigits = 0, class Archetype = signed>
         using make_fixed;
       template <int IntegerDigits, int FractionalDigits = 0, class Archetype = unsigned>
         using make_ufixed;
 
-	  template <class ReprType, int Exponent, int NumBytes>
-	    struct set_width<fixed_point<ReprType, Exponent>, NumBytes>;
+	  template <class Rep, int Exponent, int NumBytes>
+	    struct set_width<fixed_point<Rep, Exponent>, NumBytes>;
 
-      template <class ReprType, int Exponent>
+      template <class Rep, int Exponent>
       	constexpr bool operator==(
-      	  const fixed_point<ReprType, Exponent> & lhs,
-      	  const fixed_point<ReprType, Exponent> & rhs) noexcept;
-      template <class ReprType, int Exponent>
+      	  const fixed_point<Rep, Exponent> & lhs,
+      	  const fixed_point<Rep, Exponent> & rhs) noexcept;
+      template <class Rep, int Exponent>
         constexpr bool operator!=(
-      	  const fixed_point<ReprType, Exponent> & lhs,
-          const fixed_point<ReprType, Exponent> & rhs) noexcept;
-      template <class ReprType, int Exponent>
+      	  const fixed_point<Rep, Exponent> & lhs,
+          const fixed_point<Rep, Exponent> & rhs) noexcept;
+      template <class Rep, int Exponent>
       	constexpr bool operator<(
-      	  const fixed_point<ReprType, Exponent> & lhs,
-      	  const fixed_point<ReprType, Exponent> & rhs) noexcept;
-      template <class ReprType, int Exponent>
+      	  const fixed_point<Rep, Exponent> & lhs,
+      	  const fixed_point<Rep, Exponent> & rhs) noexcept;
+      template <class Rep, int Exponent>
       	constexpr bool operator>(
-      	  const fixed_point<ReprType, Exponent> & lhs,
-      	  const fixed_point<ReprType, Exponent> & rhs) noexcept;
-      template <class ReprType, int Exponent>
+      	  const fixed_point<Rep, Exponent> & lhs,
+      	  const fixed_point<Rep, Exponent> & rhs) noexcept;
+      template <class Rep, int Exponent>
       	constexpr bool operator>=(
-      	  const fixed_point<ReprType, Exponent> & lhs,
-      	  const fixed_point<ReprType, Exponent> & rhs) noexcept;
-      template <class ReprType, int Exponent>
+      	  const fixed_point<Rep, Exponent> & lhs,
+      	  const fixed_point<Rep, Exponent> & rhs) noexcept;
+      template <class Rep, int Exponent>
       	constexpr bool operator<=(
-      	  const fixed_point<ReprType, Exponent> & lhs,
-      	  const fixed_point<ReprType, Exponent> & rhs) noexcept;
+      	  const fixed_point<Rep, Exponent> & lhs,
+      	  const fixed_point<Rep, Exponent> & rhs) noexcept;
 
-      template <class ReprType, int Exponent>
-      	constexpr fixed_point<ReprType, Exponent> operator-(
-      	  const fixed_point<ReprType, Exponent> & rhs) noexcept;
-      template <class ReprType, int Exponent>
-      	constexpr fixed_point<ReprType, Exponent> operator+(
-      	  const fixed_point<ReprType, Exponent> & lhs,
-      	  const fixed_point<ReprType, Exponent> & rhs) noexcept;
-      template <class ReprType, int Exponent>
-      	constexpr fixed_point<ReprType, Exponent> operator-(
-      	  const fixed_point<ReprType, Exponent> & lhs,
-      	  const fixed_point<ReprType, Exponent> & rhs) noexcept;
-      template <class ReprType, int Exponent>
-      	fixed_point<ReprType, Exponent> & operator+=(
-      	  fixed_point<ReprType, Exponent> & lhs,
-      	  const fixed_point<ReprType, Exponent> & rhs) noexcept;
-      template <class ReprType, int Exponent>
-      	fixed_point<ReprType, Exponent> & operator-=(
-      	  fixed_point<ReprType, Exponent> & lhs,
-      	  const fixed_point<ReprType, Exponent> & rhs) noexcept;
-      template <class ReprType, int Exponent>
-      	fixed_point<ReprType, Exponent> & operator*=(
-      	  fixed_point<ReprType, Exponent> & lhs,
-      	  const fixed_point<ReprType, Exponent> & rhs) noexcept;
-      template <class ReprType, int Exponent>
-      	fixed_point<ReprType, Exponent> & operator/=(
-      	  fixed_point<ReprType, Exponent> & lhs,
-      	  const fixed_point<ReprType, Exponent> & rhs) noexcept;
+      template <class Rep, int Exponent>
+      	constexpr fixed_point<Rep, Exponent> operator-(
+      	  const fixed_point<Rep, Exponent> & rhs) noexcept;
+      template <class Rep, int Exponent>
+      	constexpr fixed_point<Rep, Exponent> operator+(
+      	  const fixed_point<Rep, Exponent> & lhs,
+      	  const fixed_point<Rep, Exponent> & rhs) noexcept;
+      template <class Rep, int Exponent>
+      	constexpr fixed_point<Rep, Exponent> operator-(
+      	  const fixed_point<Rep, Exponent> & lhs,
+      	  const fixed_point<Rep, Exponent> & rhs) noexcept;
+      template <class Rep, int Exponent>
+      	fixed_point<Rep, Exponent> & operator+=(
+      	  fixed_point<Rep, Exponent> & lhs,
+      	  const fixed_point<Rep, Exponent> & rhs) noexcept;
+      template <class Rep, int Exponent>
+      	fixed_point<Rep, Exponent> & operator-=(
+      	  fixed_point<Rep, Exponent> & lhs,
+      	  const fixed_point<Rep, Exponent> & rhs) noexcept;
+      template <class Rep, int Exponent>
+      	fixed_point<Rep, Exponent> & operator*=(
+      	  fixed_point<Rep, Exponent> & lhs,
+      	  const fixed_point<Rep, Exponent> & rhs) noexcept;
+      template <class Rep, int Exponent>
+      	fixed_point<Rep, Exponent> & operator/=(
+      	  fixed_point<Rep, Exponent> & lhs,
+      	  const fixed_point<Rep, Exponent> & rhs) noexcept;
 
       template <class Lhs, class Rhs>
       	constexpr auto operator==(const Lhs & lhs, const Rhs & rhs) noexcept;
@@ -580,61 +580,61 @@ Hence `m` is backed by `int` - which is 32 bits wide on most modern architecture
       	constexpr auto operator-(
       	  const Lhs & lhs,
       	  const Rhs & rhs) noexcept;
-      template <class LhsReprType, int LhsExponent, class RhsReprType, int RhsExponent>
+      template <class LhsRep, int LhsExponent, class RhsRep, int RhsExponent>
       	constexpr auto operator*(
-      	  const fixed_point<LhsReprType, LhsExponent> & lhs,
-      	  const fixed_point<RhsReprType, RhsExponent> & rhs) noexcept;
-      template <class LhsReprType, int LhsExponent, class RhsReprType, int RhsExponent>
+      	  const fixed_point<LhsRep, LhsExponent> & lhs,
+      	  const fixed_point<RhsRep, RhsExponent> & rhs) noexcept;
+      template <class LhsRep, int LhsExponent, class RhsRep, int RhsExponent>
       	constexpr auto operator/(
-      	  const fixed_point<LhsReprType, LhsExponent> & lhs,
-      	  const fixed_point<RhsReprType, RhsExponent> & rhs) noexcept;
-      template <class LhsReprType, int LhsExponent, class Integer>
+      	  const fixed_point<LhsRep, LhsExponent> & lhs,
+      	  const fixed_point<RhsRep, RhsExponent> & rhs) noexcept;
+      template <class LhsRep, int LhsExponent, class Integer>
       	constexpr auto operator*(
-      	  const fixed_point<LhsReprType, LhsExponent> & lhs,
+      	  const fixed_point<LhsRep, LhsExponent> & lhs,
       	  const Integer & rhs) noexcept;
-      template <class LhsReprType, int LhsExponent, class Integer>
+      template <class LhsRep, int LhsExponent, class Integer>
       	constexpr auto operator/(
-      	  const fixed_point<LhsReprType, LhsExponent> & lhs,
+      	  const fixed_point<LhsRep, LhsExponent> & lhs,
       	  const Integer & rhs) noexcept;
-      template <class Integer, class RhsReprType, int RhsExponent>
+      template <class Integer, class RhsRep, int RhsExponent>
       	constexpr auto operator*(
       	  const Integer & lhs,
-      	  const fixed_point<RhsReprType, RhsExponent> & rhs) noexcept;
-      template <class Integer, class RhsReprType, int RhsExponent>
+      	  const fixed_point<RhsRep, RhsExponent> & rhs) noexcept;
+      template <class Integer, class RhsRep, int RhsExponent>
       	constexpr auto operator/(
       	  const Integer & lhs,
-      	  const fixed_point<RhsReprType, RhsExponent> & rhs) noexcept;
-      template <class LhsReprType, int LhsExponent, class Float>
+      	  const fixed_point<RhsRep, RhsExponent> & rhs) noexcept;
+      template <class LhsRep, int LhsExponent, class Float>
       	constexpr auto operator*(
-      	  const fixed_point<LhsReprType, LhsExponent> & lhs,
+      	  const fixed_point<LhsRep, LhsExponent> & lhs,
       	  const Float & rhs) noexcept;
-      template <class LhsReprType, int LhsExponent, class Float>
+      template <class LhsRep, int LhsExponent, class Float>
       	constexpr auto operator/(
-      	  const fixed_point<LhsReprType, LhsExponent> & lhs,
+      	  const fixed_point<LhsRep, LhsExponent> & lhs,
       	  const Float & rhs) noexcept;
-      template <class Float, class RhsReprType, int RhsExponent>
+      template <class Float, class RhsRep, int RhsExponent>
       	constexpr auto operator*(
       	  const Float & lhs,
-      	  const fixed_point<RhsReprType, RhsExponent> & rhs) noexcept;
-      template <class Float, class RhsReprType, int RhsExponent>
+      	  const fixed_point<RhsRep, RhsExponent> & rhs) noexcept;
+      template <class Float, class RhsRep, int RhsExponent>
       	constexpr auto operator/(
       	  const Float & lhs,
-      	  const fixed_point<RhsReprType, RhsExponent> & rhs) noexcept;
-      template <class LhsReprType, int Exponent, class Rhs>
-      	fixed_point<LhsReprType, Exponent> & operator+=(fixed_point<LhsReprType, Exponent> & lhs, const Rhs & rhs) noexcept;
-      template <class LhsReprType, int Exponent, class Rhs>
-      	fixed_point<LhsReprType, Exponent> & operator-=(fixed_point<LhsReprType, Exponent> & lhs, const Rhs & rhs) noexcept;
-      template <class LhsReprType, int Exponent>
+      	  const fixed_point<RhsRep, RhsExponent> & rhs) noexcept;
+      template <class LhsRep, int Exponent, class Rhs>
+      	fixed_point<LhsRep, Exponent> & operator+=(fixed_point<LhsRep, Exponent> & lhs, const Rhs & rhs) noexcept;
+      template <class LhsRep, int Exponent, class Rhs>
+      	fixed_point<LhsRep, Exponent> & operator-=(fixed_point<LhsRep, Exponent> & lhs, const Rhs & rhs) noexcept;
+      template <class LhsRep, int Exponent>
       template <class Rhs, typename std::enable_if<std::is_arithmetic<Rhs>::value, int>::type Dummy>
-      	fixed_point<LhsReprType, Exponent> &
-      	fixed_point<LhsReprType, Exponent>::operator*=(const Rhs & rhs) noexcept;
-      template <class LhsReprType, int Exponent>
+      	fixed_point<LhsRep, Exponent> &
+      	fixed_point<LhsRep, Exponent>::operator*=(const Rhs & rhs) noexcept;
+      template <class LhsRep, int Exponent>
       template <class Rhs, typename std::enable_if<std::is_arithmetic<Rhs>::value, int>::type Dummy>
-      	fixed_point<LhsReprType, Exponent> &
-      	fixed_point<LhsReprType, Exponent>::operator/=(const Rhs & rhs) noexcept;
-      template <class ReprType, int Exponent>
-      	constexpr fixed_point<ReprType, Exponent>
-      	  sqrt(const fixed_point<ReprType, Exponent> & x) noexcept;
+      	fixed_point<LhsRep, Exponent> &
+      	fixed_point<LhsRep, Exponent>::operator/=(const Rhs & rhs) noexcept;
+      template <class Rep, int Exponent>
+      	constexpr fixed_point<Rep, Exponent>
+      	  sqrt(const fixed_point<Rep, Exponent> & x) noexcept;
 
       template <class Archetype, int NumBytes>
 	    struct set_width;
@@ -644,11 +644,11 @@ Hence `m` is backed by `int` - which is 32 bits wide on most modern architecture
 
 #### `fixed_point<>` Class Template
 
-    template <class ReprType = int, int Exponent = 0>
+    template <class Rep = int, int Exponent = 0>
     class fixed_point
     {
     public:
-      using repr_type = ReprType;
+      using repr_type = Rep;
 
       constexpr static int exponent;
       constexpr static int digits;
@@ -660,14 +660,14 @@ Hence `m` is backed by `int` - which is 32 bits wide on most modern architecture
         explicit constexpr fixed_point(S s) noexcept;
       template <class S, typename std::enable_if<std::is_floating_point<S>::value, int>::type Dummy = 0>
         explicit constexpr fixed_point(S s) noexcept;
-      template <class FromReprType, int FromExponent>
-        explicit constexpr fixed_point(const fixed_point<FromReprType, FromExponent> & rhs) noexcept;
+      template <class FromRep, int FromExponent>
+        explicit constexpr fixed_point(const fixed_point<FromRep, FromExponent> & rhs) noexcept;
       template <class S, typename std::enable_if<_impl::is_integral<S>::value, int>::type Dummy = 0>
         fixed_point & operator=(S s) noexcept;
       template <class S, typename std::enable_if<std::is_floating_point<S>::value, int>::type Dummy = 0>
         fixed_point & operator=(S s) noexcept;
-      template <class FromReprType, int FromExponent>
-        fixed_point & operator=(const fixed_point<FromReprType, FromExponent> & rhs) noexcept;
+      template <class FromRep, int FromExponent>
+        fixed_point & operator=(const fixed_point<FromRep, FromExponent> & rhs) noexcept;
 
       template <class S, typename std::enable_if<_impl::is_integral<S>::value, int>::type Dummy = 0>
         explicit constexpr operator S() const noexcept;
@@ -802,8 +802,8 @@ resolution.
 
 The `fixed_point` class template could probably - with a few caveats -
 be generated using the two fractional types, `nonnegative` and
-`negatable`, replacing the `ReprType` parameter with the integer bit
-count of `ReprType`, specifying `fastest` for the rounding mode and
+`negatable`, replacing the `Rep` parameter with the integer bit
+count of `Rep`, specifying `fastest` for the rounding mode and
 specifying `undefined` as the overflow mode.
 
 However, `fixed_point` more closely and concisely caters to the needs of
@@ -860,7 +860,7 @@ This paper revises [P0037R0](http://johnmcfarlane.github.io/fixed_point/papers/p
 * specifies behavior in case of overflow;
 * adds extra reason for choice of arithmetic operator return type;
 * corrects factual error in description of `trunc_shift_` functions;
-* adds sub-section, **Alternative Types for `ReprType`**;
+* adds sub-section, **Alternative Types for `Rep`**;
 * removes sub-section, **Alternatives to Built-in Integer Types**;
 * revises sub-section, **Alternative Policies** and renames **Alternative Return Type Policies**;
 * adds section, **Revisions**.
@@ -888,7 +888,7 @@ Items include:
 * utility header containing definitions for:
   * math and trigonometric functions and
   * a partial `numeric_limits` specialization;
-* a type, `integer`, intended to explore and illustrate the potential of custom `ReprType`;
+* a type, `integer`, intended to explore and illustrate the potential of custom `Rep`;
 * a type, `elastic`, intended to illustrate the use of `fixed_point` 
   to design better-behaved numeric types such as those presented in 
   P0106 [\[8\]](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0106r0.html);

--- a/doc/p0037.md
+++ b/doc/p0037.md
@@ -681,7 +681,7 @@ Hence `m` is backed by `int` - which is 32 bits wide on most modern architecture
         fixed_point & operator/=(const Rhs & rhs) noexcept;
 
       constexpr repr_type data() const noexcept;
-      static constexpr fixed_point from_data(repr_type repr) noexcept;
+      static constexpr fixed_point from_data(repr_type r) noexcept;
     };
 
 ### Header \<type_traits\> Synopsis

--- a/include/sg14/bits/fixed_point_extras.h
+++ b/include/sg14/bits/fixed_point_extras.h
@@ -21,8 +21,8 @@ namespace sg14 {
     ////////////////////////////////////////////////////////////////////////////////
     // sg14::abs
 
-    template<class ReprType, int Exponent, typename std::enable_if<std::is_signed<ReprType>::value, int>::type Dummy = 0>
-    constexpr auto abs(const fixed_point <ReprType, Exponent>& x) noexcept
+    template<class Rep, int Exponent, typename std::enable_if<std::is_signed<Rep>::value, int>::type Dummy = 0>
+    constexpr auto abs(const fixed_point <Rep, Exponent>& x) noexcept
     -> _fixed_point_impl::common_type_t<decltype(x), decltype(-x)>
     {
         using common_type = _fixed_point_impl::common_type_t<decltype(x), decltype(-x)>;
@@ -31,9 +31,9 @@ namespace sg14 {
                : static_cast<common_type>(-x);
     }
 
-    template<class ReprType, int Exponent, typename std::enable_if<std::is_unsigned<ReprType>::value, int>::type Dummy = 0>
-    constexpr fixed_point <ReprType, Exponent>
-    abs(const fixed_point <ReprType, Exponent>& x) noexcept
+    template<class Rep, int Exponent, typename std::enable_if<std::is_unsigned<Rep>::value, int>::type Dummy = 0>
+    constexpr fixed_point <Rep, Exponent>
+    abs(const fixed_point <Rep, Exponent>& x) noexcept
     {
         return x;
     }
@@ -42,34 +42,34 @@ namespace sg14 {
     // sg14::sqrt helper functions
 
     namespace _fixed_point_impl {
-        template<class ReprType>
-        constexpr ReprType sqrt_bit(
-                ReprType n,
-                ReprType bit = ReprType(1) << (width<ReprType>::value-2))
+        template<class Rep>
+        constexpr Rep sqrt_bit(
+                Rep n,
+                Rep bit = Rep(1) << (width<Rep>::value-2))
         {
-            return (bit>n) ? sqrt_bit<ReprType>(n, bit >> 2) : bit;
+            return (bit>n) ? sqrt_bit<Rep>(n, bit >> 2) : bit;
         }
 
-        template<class ReprType>
-        constexpr ReprType sqrt_solve3(
-                ReprType n,
-                ReprType bit,
-                ReprType result)
+        template<class Rep>
+        constexpr Rep sqrt_solve3(
+                Rep n,
+                Rep bit,
+                Rep result)
         {
-            return (bit!=ReprType{0})
+            return (bit!=Rep{0})
                    ? (n>=result+bit)
-                     ? sqrt_solve3<ReprType>(
-                                    static_cast<ReprType>(n-(result+bit)),
+                     ? sqrt_solve3<Rep>(
+                                    static_cast<Rep>(n-(result+bit)),
                                     bit >> 2,
-                                    static_cast<ReprType>((result >> 1)+bit))
-                     : sqrt_solve3<ReprType>(n, bit >> 2, result >> 1)
+                                    static_cast<Rep>((result >> 1)+bit))
+                     : sqrt_solve3<Rep>(n, bit >> 2, result >> 1)
                    : result;
         }
 
-        template<class ReprType>
-        constexpr ReprType sqrt_solve1(ReprType n)
+        template<class Rep>
+        constexpr Rep sqrt_solve1(Rep n)
         {
-            return sqrt_solve3<ReprType>(n, sqrt_bit<ReprType>(n), ReprType{0});
+            return sqrt_solve3<Rep>(n, sqrt_bit<Rep>(n), Rep{0});
         }
     }
 
@@ -78,18 +78,18 @@ namespace sg14 {
 
     // https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Binary_numeral_system_.28base_2.29
     // placeholder implementation; slow when calculated at run-time?
-    template<class ReprType, int Exponent>
-    constexpr fixed_point <ReprType, Exponent>
-    sqrt(const fixed_point <ReprType, Exponent>& x)
+    template<class Rep, int Exponent>
+    constexpr fixed_point <Rep, Exponent>
+    sqrt(const fixed_point <Rep, Exponent>& x)
     {
-        using widened_type = fixed_point<set_width_t<ReprType, width<ReprType>::value*2>, Exponent*2>;
+        using widened_type = fixed_point<set_width_t<Rep, width<Rep>::value*2>, Exponent*2>;
         return
 #if defined(_SG14_FIXED_POINT_EXCEPTIONS_ENABLED)
-                (x<fixed_point<ReprType, Exponent>(0))
+                (x<fixed_point<Rep, Exponent>(0))
                 ? throw std::invalid_argument("cannot represent square root of negative value") :
 #endif
-                fixed_point<ReprType, Exponent>::from_data(
-                        static_cast<ReprType>(_fixed_point_impl::sqrt_solve1(widened_type{x}.data())));
+                fixed_point<Rep, Exponent>::from_data(
+                        static_cast<Rep>(_fixed_point_impl::sqrt_solve1(widened_type{x}.data())));
     }
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -100,55 +100,55 @@ namespace sg14 {
     // many <cmath> functions are not constexpr.
 
     namespace _fixed_point_impl {
-        template<class ReprType, int Exponent, float_of_same_size<ReprType>(* F)(
-                float_of_same_size<ReprType>)>
-        constexpr fixed_point <ReprType, Exponent>
-        crib(const fixed_point <ReprType, Exponent>& x) noexcept
+        template<class Rep, int Exponent, float_of_same_size<Rep>(* F)(
+                float_of_same_size<Rep>)>
+        constexpr fixed_point <Rep, Exponent>
+        crib(const fixed_point <Rep, Exponent>& x) noexcept
         {
-            using floating_point = float_of_same_size<ReprType>;
-            return static_cast<fixed_point<ReprType, Exponent>>(F(static_cast<floating_point>(x)));
+            using floating_point = float_of_same_size<Rep>;
+            return static_cast<fixed_point<Rep, Exponent>>(F(static_cast<floating_point>(x)));
         }
     }
 
-    template<class ReprType, int Exponent>
-    constexpr fixed_point <ReprType, Exponent>
-    sin(const fixed_point <ReprType, Exponent>& x) noexcept
+    template<class Rep, int Exponent>
+    constexpr fixed_point <Rep, Exponent>
+    sin(const fixed_point <Rep, Exponent>& x) noexcept
     {
-        return _fixed_point_impl::crib<ReprType, Exponent, std::sin>(x);
+        return _fixed_point_impl::crib<Rep, Exponent, std::sin>(x);
     }
 
-    template<class ReprType, int Exponent>
-    constexpr fixed_point <ReprType, Exponent>
-    cos(const fixed_point <ReprType, Exponent>& x) noexcept
+    template<class Rep, int Exponent>
+    constexpr fixed_point <Rep, Exponent>
+    cos(const fixed_point <Rep, Exponent>& x) noexcept
     {
-        return _fixed_point_impl::crib<ReprType, Exponent, std::cos>(x);
+        return _fixed_point_impl::crib<Rep, Exponent, std::cos>(x);
     }
 
-    template<class ReprType, int Exponent>
-    constexpr fixed_point <ReprType, Exponent>
-    exp(const fixed_point <ReprType, Exponent>& x) noexcept
+    template<class Rep, int Exponent>
+    constexpr fixed_point <Rep, Exponent>
+    exp(const fixed_point <Rep, Exponent>& x) noexcept
     {
-        return _fixed_point_impl::crib<ReprType, Exponent, std::exp>(x);
+        return _fixed_point_impl::crib<Rep, Exponent, std::exp>(x);
     }
 
-    template<class ReprType, int Exponent>
-    constexpr fixed_point <ReprType, Exponent>
-    pow(const fixed_point <ReprType, Exponent>& x) noexcept
+    template<class Rep, int Exponent>
+    constexpr fixed_point <Rep, Exponent>
+    pow(const fixed_point <Rep, Exponent>& x) noexcept
     {
-        return _fixed_point_impl::crib<ReprType, Exponent, std::pow>(x);
+        return _fixed_point_impl::crib<Rep, Exponent, std::pow>(x);
     }
 
     ////////////////////////////////////////////////////////////////////////////////
     // sg14::fixed_point streaming - (placeholder implementation)
 
-    template<class ReprType, int Exponent>
-    ::std::ostream& operator<<(::std::ostream& out, const fixed_point <ReprType, Exponent>& fp)
+    template<class Rep, int Exponent>
+    ::std::ostream& operator<<(::std::ostream& out, const fixed_point <Rep, Exponent>& fp)
     {
         return out << static_cast<long double>(fp);
     }
 
-    template<class ReprType, int Exponent>
-    ::std::istream& operator>>(::std::istream& in, fixed_point <ReprType, Exponent>& fp)
+    template<class Rep, int Exponent>
+    ::std::istream& operator>>(::std::istream& in, fixed_point <Rep, Exponent>& fp)
     {
         long double ld;
         in >> ld;
@@ -164,10 +164,10 @@ namespace std {
     // note: some members are guessed,
     // some are temporary (assuming rounding style, traps etc.)
     // and some are undefined
-    template<class ReprType, int Exponent>
-    struct numeric_limits<sg14::fixed_point<ReprType, Exponent>> {
+    template<class Rep, int Exponent>
+    struct numeric_limits<sg14::fixed_point<Rep, Exponent>> {
         // fixed-point-specific helpers
-        using _value_type = sg14::fixed_point<ReprType, Exponent>;
+        using _value_type = sg14::fixed_point<Rep, Exponent>;
         using _repr_type = typename _value_type::repr_type;
         using _repr_numeric_limits = numeric_limits<_repr_type>;
 

--- a/include/sg14/bits/fixed_point_extras.h
+++ b/include/sg14/bits/fixed_point_extras.h
@@ -168,8 +168,8 @@ namespace std {
     struct numeric_limits<sg14::fixed_point<Rep, Exponent>> {
         // fixed-point-specific helpers
         using _value_type = sg14::fixed_point<Rep, Exponent>;
-        using _repr_type = typename _value_type::repr_type;
-        using _repr_numeric_limits = numeric_limits<_repr_type>;
+        using _rep = typename _value_type::rep;
+        using _repr_numeric_limits = numeric_limits<_rep>;
 
         // standard members
 
@@ -209,7 +209,7 @@ namespace std {
             return _value_type::from_data(1);
         }
 
-        // TODO: not even sure about this when repr_type is built-in integral
+        // TODO: not even sure about this when rep is built-in integral
         static constexpr _value_type round_error() noexcept
         {
             return static_cast<_value_type>(1);

--- a/include/sg14/bits/fixed_point_extras.h
+++ b/include/sg14/bits/fixed_point_extras.h
@@ -169,7 +169,7 @@ namespace std {
         // fixed-point-specific helpers
         using _value_type = sg14::fixed_point<Rep, Exponent>;
         using _rep = typename _value_type::rep;
-        using _repr_numeric_limits = numeric_limits<_rep>;
+        using _rep_numeric_limits = numeric_limits<_rep>;
 
         // standard members
 
@@ -182,26 +182,26 @@ namespace std {
 
         static constexpr _value_type max() noexcept
         {
-            return _value_type::from_data(_repr_numeric_limits::max());
+            return _value_type::from_data(_rep_numeric_limits::max());
         }
 
         static constexpr _value_type lowest() noexcept
         {
-            return _value_type::from_data(_repr_numeric_limits::lowest());
+            return _value_type::from_data(_rep_numeric_limits::lowest());
         }
 
-        static constexpr int digits = _repr_numeric_limits::digits;
+        static constexpr int digits = _rep_numeric_limits::digits;
 
         //static constexpr int digits10 = ?;
         //static constexpr int max_digits10 = ?;
 
-        static constexpr bool is_signed = _repr_numeric_limits::is_signed;
-        static constexpr bool is_integer = _repr_numeric_limits::is_integer;
+        static constexpr bool is_signed = _rep_numeric_limits::is_signed;
+        static constexpr bool is_integer = _rep_numeric_limits::is_integer;
 
         // TODO: not entirely certain
         static constexpr bool is_exact = true;
 
-        static constexpr int radix = _repr_numeric_limits::radix;
+        static constexpr int radix = _rep_numeric_limits::radix;
         static_assert(radix==2, "fixed-point must be represented using binary type");
 
         static constexpr _value_type epsilon() noexcept
@@ -250,11 +250,11 @@ namespace std {
 
         static constexpr bool is_iec559 = false;
         static constexpr bool is_bounded = true;
-        static constexpr bool is_modulo = _repr_numeric_limits::is_modulo;
+        static constexpr bool is_modulo = _rep_numeric_limits::is_modulo;
 
-        static constexpr bool traps = _repr_numeric_limits::traps;
+        static constexpr bool traps = _rep_numeric_limits::traps;
         static constexpr bool tinyness_before = false;
-        static constexpr float_round_style round_style = _repr_numeric_limits::round_style;
+        static constexpr float_round_style round_style = _rep_numeric_limits::round_style;
     };
 }
 

--- a/include/sg14/elastic.h
+++ b/include/sg14/elastic.h
@@ -497,10 +497,10 @@ namespace sg14 {
     {
         using result_type = _elastic_impl::multiply_result_type<LhsIntegerDigits, LhsFractionalDigits, LhsArchetype, RhsIntegerDigits, RhsFractionalDigits, RhsArchetype>;
         using fixed_point_result_type = typename result_type::_fixed_point_type;
-        using fixed_point_result_repr_type = typename fixed_point_result_type::repr_type;
+        using fixed_point_result_rep = typename fixed_point_result_type::rep;
 
-        using lhs_intermediate_fixed_point_type = fixed_point<fixed_point_result_repr_type, -LhsFractionalDigits>;
-        using rhs_intermediate_fixed_point_type = fixed_point<fixed_point_result_repr_type, -RhsFractionalDigits>;
+        using lhs_intermediate_fixed_point_type = fixed_point<fixed_point_result_rep, -LhsFractionalDigits>;
+        using rhs_intermediate_fixed_point_type = fixed_point<fixed_point_result_rep, -RhsFractionalDigits>;
 
         return static_cast<result_type>(
                 sg14::multiply<fixed_point_result_type>(
@@ -540,7 +540,7 @@ namespace std {
         using _fixed_point_limits = numeric_limits<_fixed_point_type>;
         static_assert(_fixed_point_limits::is_specialized,
                 "specialization of sg14::fixed_point<> is necessary for specialization of sg14::elastic<>");
-        using _fixed_point_repr_type = typename _fixed_point_type::repr_type;
+        using _fixed_point_rep = typename _fixed_point_type::rep;
 
         // standard members
 
@@ -555,16 +555,16 @@ namespace std {
         {
             return static_cast<_value_type>(
                     _fixed_point_type::from_data(
-                            numeric_limits<_fixed_point_repr_type>::max()
-                                    >> (numeric_limits<_fixed_point_repr_type>::digits-digits)));
+                            numeric_limits<_fixed_point_rep>::max()
+                                    >> (numeric_limits<_fixed_point_rep>::digits-digits)));
         }
 
         static constexpr _value_type lowest() noexcept
         {
             return static_cast<_value_type>(
                     _fixed_point_type::from_data(
-                            numeric_limits<_fixed_point_repr_type>::lowest()
-                                    >> (numeric_limits<_fixed_point_repr_type>::digits-digits)));
+                            numeric_limits<_fixed_point_rep>::lowest()
+                                    >> (numeric_limits<_fixed_point_rep>::digits-digits)));
         }
 
         static constexpr int digits = _value_type::integer_digits+_value_type::fractional_digits;

--- a/include/sg14/elastic.h
+++ b/include/sg14/elastic.h
@@ -103,9 +103,9 @@ namespace sg14 {
             : is_signed<Archetype> {
     };
 
-    template<class ReprType, int Exponent>
-    struct is_signed<fixed_point<ReprType, Exponent>>
-            : is_signed<ReprType> {
+    template<class Rep, int Exponent>
+    struct is_signed<fixed_point<Rep, Exponent>>
+            : is_signed<Rep> {
     };
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -116,9 +116,9 @@ namespace sg14 {
             : is_unsigned<Archetype> {
     };
 
-    template<class ReprType, int Exponent>
-    struct is_unsigned<fixed_point<ReprType, Exponent>>
-            : is_unsigned<ReprType> {
+    template<class Rep, int Exponent>
+    struct is_unsigned<fixed_point<Rep, Exponent>>
+            : is_unsigned<Rep> {
     };
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -215,8 +215,8 @@ namespace sg14 {
                 :_value(rhs._data()) { }
 
         /// constructor taking fixed_point type
-        template<class RhsReprType, int RhsExponent>
-        explicit constexpr elastic(const fixed_point<RhsReprType, RhsExponent>& value)
+        template<class RhsRep, int RhsExponent>
+        explicit constexpr elastic(const fixed_point<RhsRep, RhsExponent>& value)
                 :_value(value) { }
 
         /// constructor converting from any other type

--- a/include/sg14/fixed_point.h
+++ b/include/sg14/fixed_point.h
@@ -263,7 +263,7 @@ namespace sg14 {
         // types
 
         /// alias to template parameter, \a Rep
-        using repr_type = Rep;
+        using rep = Rep;
 
         ////////////////////////////////////////////////////////////////////////////////
         // constants
@@ -288,7 +288,7 @@ namespace sg14 {
 
     private:
         // constructor taking representation explicitly using operator++(int)-style trick
-        constexpr fixed_point(repr_type r, int)
+        constexpr fixed_point(rep r, int)
                 :_r(r)
         {
         }
@@ -369,13 +369,13 @@ namespace sg14 {
         fixed_point& operator/=(const Rhs& rhs);
 
         /// returns internal representation of value
-        constexpr repr_type data() const
+        constexpr rep data() const
         {
             return _r;
         }
 
         /// creates an instance given the underlying representation value
-        static constexpr fixed_point from_data(repr_type r)
+        static constexpr fixed_point from_data(rep r)
         {
             return fixed_point(r, 0);
         }
@@ -401,15 +401,15 @@ namespace sg14 {
         }
 
         template<class S>
-        static constexpr repr_type integral_to_repr(S s)
+        static constexpr rep integral_to_repr(S s)
         {
             static_assert(is_integral<S>::value, "S must be unsigned integral type");
 
-            return _fixed_point_impl::shift_right<exponent, repr_type>(s);
+            return _fixed_point_impl::shift_right<exponent, rep>(s);
         }
 
         template<class S>
-        static constexpr S repr_to_integral(repr_type r)
+        static constexpr S repr_to_integral(rep r)
         {
             static_assert(is_integral<S>::value, "S must be unsigned integral type");
 
@@ -417,40 +417,40 @@ namespace sg14 {
         }
 
         template<class S>
-        static constexpr repr_type floating_point_to_repr(S s)
+        static constexpr rep floating_point_to_repr(S s)
         {
             static_assert(std::is_floating_point<S>::value, "S must be floating-point type");
-            return static_cast<repr_type>(s*one<S>());
+            return static_cast<rep>(s*one<S>());
         }
 
         template<class S>
-        static constexpr S repr_to_floating_point(repr_type r)
+        static constexpr S repr_to_floating_point(rep r)
         {
             static_assert(std::is_floating_point<S>::value, "S must be floating-point type");
             return S(r)*inverse_one<S>();
         }
 
         template<class FromRep, int FromExponent>
-        static constexpr repr_type fixed_point_to_repr(const fixed_point<FromRep, FromExponent>& rhs)
+        static constexpr rep fixed_point_to_repr(const fixed_point<FromRep, FromExponent>& rhs)
         {
-            return _fixed_point_impl::shift_right<(exponent-FromExponent), repr_type>(rhs.data());
+            return _fixed_point_impl::shift_right<(exponent-FromExponent), rep>(rhs.data());
         }
 
         ////////////////////////////////////////////////////////////////////////////////
         // variables
 
-        repr_type _r;
+        rep _r;
     };
 
     /// \brief Produce a fixed-point type with the given number of integer and fractional digits.
     ///
     /// \tparam IntegerDigits specifies minimum value of @ref fixed_point::integer_digits
     /// \tparam FractionalDigits specifies the exact value of @ref fixed_point::fractional_digits
-    /// \tparam Archetype hints at the type of @ref fixed_point::repr_type
+    /// \tparam Archetype hints at the type of @ref fixed_point::rep
     ///
     /// \remarks The signage of \a Archetype specifies signage of the resultant fixed-point type.
     /// \remarks Typical choices for \a Archetype, `signed` and `unsigned`,
-    /// result in a type that uses built-in integers for \a fixed_point::repr_type.
+    /// result in a type that uses built-in integers for \a fixed_point::rep.
     /// \remarks Resultant type is signed by default.
     ///
     /// \par Example:
@@ -515,7 +515,7 @@ namespace sg14 {
         template<class FixedPoint>
         struct widen_integer_result {
             using type = fixed_point<
-                    _fixed_point_impl::next_size<typename FixedPoint::repr_type>,
+                    _fixed_point_impl::next_size<typename FixedPoint::rep>,
                     FixedPoint::exponent>;
         };
 
@@ -538,13 +538,13 @@ namespace sg14 {
         // and the same number of integer bits
         template<class FixedPoint>
         struct widen_fractional_result {
-            using prev_repr_type = typename FixedPoint::repr_type;
-            using next_repr_type = _fixed_point_impl::next_size<prev_repr_type>;
+            using prev_rep = typename FixedPoint::rep;
+            using next_rep = _fixed_point_impl::next_size<prev_rep>;
 
             using type = fixed_point<
-                    next_repr_type,
-                    FixedPoint::exponent+static_cast<int>(width<prev_repr_type>::value)
-                            -static_cast<int>(width<next_repr_type>::value)>;
+                    next_rep,
+                    FixedPoint::exponent+static_cast<int>(width<prev_rep>::value)
+                            -static_cast<int>(width<next_rep>::value)>;
         };
 
         template<class FixedPoint>
@@ -573,7 +573,7 @@ namespace sg14 {
 
             template<class Lhs, class Rhs>
             using common_type = fixed_point<
-                    typename sg14::common_type<typename Lhs::repr_type, typename Rhs::repr_type>::type,
+                    typename sg14::common_type<typename Lhs::rep, typename Rhs::rep>::type,
                     exponent<Lhs, Rhs>::value>;
 
             template<class Lhs, class Rhs>
@@ -588,7 +588,7 @@ namespace sg14 {
             template<class Rhs>
             struct negate {
                 using result_type = fixed_point<
-                        decltype(-std::declval<typename Rhs::repr_type>()),
+                        decltype(-std::declval<typename Rhs::rep>()),
                         Rhs::exponent>;
 
                 using rhs_type = Rhs;
@@ -597,21 +597,21 @@ namespace sg14 {
             template<class Lhs, class Rhs>
             struct add : operator_base<Lhs, Rhs> {
                 using result_type = fixed_point<
-                        decltype(std::declval<typename Lhs::repr_type>()+std::declval<typename Rhs::repr_type>()),
+                        decltype(std::declval<typename Lhs::rep>()+std::declval<typename Rhs::rep>()),
                         exponent<Lhs, Rhs>::value>;
             };
 
             template<class Lhs, class Rhs>
             struct subtract : operator_base<Lhs, Rhs> {
                 using result_type = fixed_point<
-                        decltype(std::declval<typename Lhs::repr_type>()-std::declval<typename Rhs::repr_type>()),
+                        decltype(std::declval<typename Lhs::rep>()-std::declval<typename Rhs::rep>()),
                         exponent<Lhs, Rhs>::value>;
             };
 
             template<class Lhs, class Rhs>
             struct multiply : operator_base<Lhs, Rhs> {
                 using result_type = fixed_point<
-                        decltype(std::declval<typename Lhs::repr_type>()*std::declval<typename Rhs::repr_type>()),
+                        decltype(std::declval<typename Lhs::rep>()*std::declval<typename Rhs::rep>()),
                         exponent<Lhs, Rhs>::value>;
                 using lhs_type = widen_integer_result_t<Lhs>;
             };
@@ -619,7 +619,7 @@ namespace sg14 {
             template<class Lhs, class Rhs>
             struct divide : operator_base<Lhs, Rhs> {
                 using result_type = fixed_point<
-                        decltype(std::declval<typename Lhs::repr_type>()/std::declval<typename Rhs::repr_type>()),
+                        decltype(std::declval<typename Lhs::rep>()/std::declval<typename Rhs::rep>()),
                         exponent<Lhs, Rhs>::value>;
                 using lhs_type = widen_fractional_result_t<Lhs>;
             };
@@ -714,7 +714,7 @@ namespace sg14 {
     template<class Result, class Rhs>
     constexpr Result negate(const Rhs& rhs)
     {
-        static_assert(is_signed<typename Result::repr_type>::value, "unary negation of unsigned value");
+        static_assert(is_signed<typename Result::rep>::value, "unary negation of unsigned value");
 
         return Result::from_data(-static_cast<Result>(rhs).data());
     }
@@ -724,7 +724,7 @@ namespace sg14 {
     constexpr Result add(const Lhs& lhs, const Rhs& rhs)
     {
         return Result::from_data(
-                static_cast<typename Result::repr_type>(
+                static_cast<typename Result::rep>(
                         static_cast<Result>(lhs).data()
                                 +static_cast<Result>(rhs).data()));
     }
@@ -742,22 +742,22 @@ namespace sg14 {
     template<class Result, class Lhs, class Rhs>
     constexpr Result multiply(const Lhs& lhs, const Rhs& rhs)
     {
-        using result_repr_type = typename Result::repr_type;
+        using result_rep = typename Result::rep;
         return Result::from_data(
                 _fixed_point_impl::shift_left<
                         (Lhs::exponent+Rhs::exponent-Result::exponent),
-                        result_repr_type>(lhs.data()*rhs.data()));
+                        result_rep>(lhs.data()*rhs.data()));
     }
 
     // sg14::divide
     template<class Result, class Lhs, class Rhs>
     constexpr Result divide(const Lhs& lhs, const Rhs& rhs)
     {
-        using result_repr_type = typename Result::repr_type;
+        using result_rep = typename Result::rep;
         return Result::from_data(
                 _fixed_point_impl::shift_left<
                         (Lhs::exponent-Rhs::exponent-Result::exponent),
-                        result_repr_type>(lhs.data()/rhs.data()));
+                        result_rep>(lhs.data()/rhs.data()));
     }
 
     namespace _fixed_point_impl {
@@ -1023,8 +1023,8 @@ namespace sg14 {
     constexpr auto operator*(const fixed_point<Rep, Exponent>& lhs, const Integer& rhs)
     -> fixed_point<decltype(std::declval<Rep>()*std::declval<Integer>()), Exponent>
     {
-        using repr_type = fixed_point<decltype(std::declval<Rep>()*std::declval<Integer>()), Exponent>;
-        return multiply<repr_type>(lhs, fixed_point<Integer>(rhs));
+        using rep = fixed_point<decltype(std::declval<Rep>()*std::declval<Integer>()), Exponent>;
+        return multiply<rep>(lhs, fixed_point<Integer>(rhs));
     }
 
     template<
@@ -1129,7 +1129,7 @@ namespace sg14 {
     fixed_point<LhsRep, Exponent>&
     fixed_point<LhsRep, Exponent>::operator*=(const Rhs& rhs)
     {
-        _r *= static_cast<repr_type>(rhs);
+        _r *= static_cast<rep>(rhs);
         return *this;
     }
 
@@ -1138,7 +1138,7 @@ namespace sg14 {
     fixed_point<LhsRep, Exponent>&
     fixed_point<LhsRep, Exponent>::operator/=(const Rhs& rhs)
     {
-        _r /= static_cast<repr_type>(rhs);
+        _r /= static_cast<rep>(rhs);
         return *this;
     }
 }

--- a/include/sg14/fixed_point.h
+++ b/include/sg14/fixed_point.h
@@ -288,8 +288,8 @@ namespace sg14 {
 
     private:
         // constructor taking representation explicitly using operator++(int)-style trick
-        constexpr fixed_point(repr_type repr, int)
-                :_r(repr)
+        constexpr fixed_point(repr_type r, int)
+                :_r(r)
         {
         }
 
@@ -375,9 +375,9 @@ namespace sg14 {
         }
 
         /// creates an instance given the underlying representation value
-        static constexpr fixed_point from_data(repr_type repr)
+        static constexpr fixed_point from_data(repr_type r)
         {
-            return fixed_point(repr, 0);
+            return fixed_point(r, 0);
         }
 
     private:

--- a/include/sg14/fixed_point.h
+++ b/include/sg14/fixed_point.h
@@ -700,8 +700,8 @@ namespace sg14 {
         template<typename LhsFixedPoint, typename RhsFixedPoint>
         using subtract_result_repr = typename make_signed<typename sg14::common_type<LhsFixedPoint, RhsFixedPoint>::type>::type;
 
-        template<typename Repr>
-        using square_result_repr = typename make_unsigned<Repr>::type;
+        template<typename Rep>
+        using square_result_repr = typename make_unsigned<Rep>::type;
 
         template<typename FixedPoint>
         using sqrt_result_repr = typename make_unsigned<FixedPoint>::type;

--- a/include/sg14/fixed_point.h
+++ b/include/sg14/fixed_point.h
@@ -248,7 +248,7 @@ namespace sg14 {
 
     /// \brief literal real number approximation that uses fixed-point arithmetic
     ///
-    /// \tparam ReprType the underlying type used to represent the value
+    /// \tparam Rep the underlying type used to represent the value
     /// \tparam Exponent the value by which to scale the integer value in order to get the real value
     ///
     /// \par Examples
@@ -256,14 +256,14 @@ namespace sg14 {
     /// To define a fixed-point value 1 byte in size with a sign bit, 3 integer bits and 4 fractional bits:
     /// \snippet snippets.cpp define a fixed_point value
 
-    template<class ReprType = int, int Exponent = 0>
+    template<class Rep = int, int Exponent = 0>
     class fixed_point {
     public:
         ////////////////////////////////////////////////////////////////////////////////
         // types
 
-        /// alias to template parameter, \a ReprType
-        using repr_type = ReprType;
+        /// alias to template parameter, \a Rep
+        using repr_type = Rep;
 
         ////////////////////////////////////////////////////////////////////////////////
         // constants
@@ -273,7 +273,7 @@ namespace sg14 {
 
         /// number of binary digits this type can represent;
         /// equivalent to [std::numeric_limits::digits](http://en.cppreference.com/w/cpp/types/numeric_limits/digits)
-        constexpr static int digits = width<ReprType>::value-is_signed<ReprType>::value;
+        constexpr static int digits = width<Rep>::value-is_signed<Rep>::value;
 
         /// number of binary digits devoted to integer part of value;
         /// can be negative for specializations with especially small ranges
@@ -312,8 +312,8 @@ namespace sg14 {
         }
 
         /// constructor taking a fixed-point type
-        template<class FromReprType, int FromExponent>
-        explicit constexpr fixed_point(const fixed_point<FromReprType, FromExponent>& rhs)
+        template<class FromRep, int FromExponent>
+        explicit constexpr fixed_point(const fixed_point<FromRep, FromExponent>& rhs)
                 :_repr(fixed_point_to_repr(rhs))
         {
         }
@@ -335,8 +335,8 @@ namespace sg14 {
         }
 
         /// copy assignement operator taking a fixed-point type
-        template<class FromReprType, int FromExponent>
-        fixed_point& operator=(const fixed_point<FromReprType, FromExponent>& rhs)
+        template<class FromRep, int FromExponent>
+        fixed_point& operator=(const fixed_point<FromRep, FromExponent>& rhs)
         {
             _repr = fixed_point_to_repr(rhs);
             return *this;
@@ -430,8 +430,8 @@ namespace sg14 {
             return S(r)*inverse_one<S>();
         }
 
-        template<class FromReprType, int FromExponent>
-        static constexpr repr_type fixed_point_to_repr(const fixed_point<FromReprType, FromExponent>& rhs)
+        template<class FromRep, int FromExponent>
+        static constexpr repr_type fixed_point_to_repr(const fixed_point<FromRep, FromExponent>& rhs)
         {
             return _fixed_point_impl::shift_right<(exponent-FromExponent), repr_type>(rhs.data());
         }
@@ -475,15 +475,15 @@ namespace sg14 {
 
     /// produces equivalent fixed-point type at a new width
     ///
-    /// \tparam ReprType the \a ReprType parameter of @ref fixed_point
+    /// \tparam Rep the \a Rep parameter of @ref fixed_point
     /// \tparam Exponent the \a Exponent parameter of @ref fixed_point
     /// \tparam MinNumBits the desired size of the resultant type such that `(width<type>::value >= MinNumBytes)`
     ///
     /// \sa set_width_t
-    template<class ReprType, int Exponent, _width_type MinNumBits>
-    struct set_width<fixed_point<ReprType, Exponent>, MinNumBits> {
+    template<class Rep, int Exponent, _width_type MinNumBits>
+    struct set_width<fixed_point<Rep, Exponent>, MinNumBits> {
         /// resultant type; a fixed_point specialization that is at least \a MinNumBits bytes in width
-        using type = fixed_point<set_width_t<ReprType, MinNumBits>, Exponent>;
+        using type = fixed_point<set_width_t<Rep, MinNumBits>, Exponent>;
     };
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -501,8 +501,8 @@ namespace sg14 {
                 : public std::false_type {
         };
 
-        template<class ReprType, int Exponent>
-        struct is_fixed_point<fixed_point<ReprType, Exponent>>
+        template<class Rep, int Exponent>
+        struct is_fixed_point<fixed_point<Rep, Exponent>>
                 : public std::true_type {
         };
 
@@ -633,22 +633,22 @@ namespace sg14 {
 
         // given a fixed-point and a integer type,
         // generates a fixed-point type that is as big as both of them (or as close as possible)
-        template<class LhsReprType, int LhsExponent, class RhsInteger>
+        template<class LhsRep, int LhsExponent, class RhsInteger>
         struct _common_type_mixed<
-                fixed_point<LhsReprType, LhsExponent>,
+                fixed_point<LhsRep, LhsExponent>,
                 RhsInteger,
                 typename std::enable_if<is_integral<RhsInteger>::value>::type> {
-            using type = fixed_point<typename sg14::common_type<LhsReprType, RhsInteger>::type, LhsExponent>;
+            using type = fixed_point<typename sg14::common_type<LhsRep, RhsInteger>::type, LhsExponent>;
         };
 
         // given a fixed-point and a floating-point type,
         // generates a floating-point type that is as big as both of them (or as close as possible)
-        template<class LhsReprType, int LhsExponent, class Float>
+        template<class LhsRep, int LhsExponent, class Float>
         struct _common_type_mixed<
-                fixed_point<LhsReprType, LhsExponent>,
+                fixed_point<LhsRep, LhsExponent>,
                 Float,
                 typename std::enable_if<std::is_floating_point<Float>::value>::type>
-                : sg14::common_type<float_of_same_size<LhsReprType>, Float> {
+                : sg14::common_type<float_of_same_size<LhsRep>, Float> {
         };
 
         ////////////////////////////////////////////////////////////////////////////////
@@ -657,33 +657,33 @@ namespace sg14 {
         template<class ... T>
         struct common_type;
 
-        template<class ReprType, int Exponent>
-        struct common_type<fixed_point<ReprType, Exponent>> {
+        template<class Rep, int Exponent>
+        struct common_type<fixed_point<Rep, Exponent>> {
             using type = fixed_point<
-                    typename sg14::common_type<ReprType>::type,
+                    typename sg14::common_type<Rep>::type,
                     Exponent>;
         };
 
-        template<class LhsReprType, int LhsExponent, class Rhs>
-        struct common_type<fixed_point<LhsReprType, LhsExponent>, Rhs> {
+        template<class LhsRep, int LhsExponent, class Rhs>
+        struct common_type<fixed_point<LhsRep, LhsExponent>, Rhs> {
             static_assert(!_fixed_point_impl::is_fixed_point<Rhs>::value, "fixed-point Rhs type");
-            using type = typename _common_type_mixed<fixed_point<LhsReprType, LhsExponent>, Rhs>::type;
+            using type = typename _common_type_mixed<fixed_point<LhsRep, LhsExponent>, Rhs>::type;
         };
 
-        template<class Lhs, class RhsReprType, int RhsExponent>
-        struct common_type<Lhs, fixed_point<RhsReprType, RhsExponent>> {
+        template<class Lhs, class RhsRep, int RhsExponent>
+        struct common_type<Lhs, fixed_point<RhsRep, RhsExponent>> {
             static_assert(!_fixed_point_impl::is_fixed_point<Lhs>::value, "fixed-point Lhs type");
-            using type = typename _common_type_mixed<fixed_point<RhsReprType, RhsExponent>, Lhs>::type;
+            using type = typename _common_type_mixed<fixed_point<RhsRep, RhsExponent>, Lhs>::type;
         };
 
-        template<class LhsReprType, int LhsExponent, class RhsReprType, int RhsExponent>
+        template<class LhsRep, int LhsExponent, class RhsRep, int RhsExponent>
         struct common_type<
-                fixed_point<LhsReprType, LhsExponent>,
-                fixed_point<RhsReprType, RhsExponent>> {
+                fixed_point<LhsRep, LhsExponent>,
+                fixed_point<RhsRep, RhsExponent>> {
             using type =
             typename default_arithmetic_policy::common_type<
-                    fixed_point<LhsReprType, LhsExponent>,
-                    fixed_point<RhsReprType, RhsExponent>>;
+                    fixed_point<LhsRep, LhsExponent>,
+                    fixed_point<RhsRep, RhsExponent>>;
         };
 
         ////////////////////////////////////////////////////////////////////////////////
@@ -822,50 +822,50 @@ namespace sg14 {
     ////////////////////////////////////////////////////////////////////////////////
     // (fixed_point @ fixed_point) comparison operators
 
-    template<class ReprType, int Exponent>
+    template<class Rep, int Exponent>
     constexpr bool operator==(
-            const fixed_point<ReprType, Exponent>& lhs,
-            const fixed_point<ReprType, Exponent>& rhs)
+            const fixed_point<Rep, Exponent>& lhs,
+            const fixed_point<Rep, Exponent>& rhs)
     {
         return lhs.data()==rhs.data();
     }
 
-    template<class ReprType, int Exponent>
+    template<class Rep, int Exponent>
     constexpr bool operator!=(
-            const fixed_point<ReprType, Exponent>& lhs,
-            const fixed_point<ReprType, Exponent>& rhs)
+            const fixed_point<Rep, Exponent>& lhs,
+            const fixed_point<Rep, Exponent>& rhs)
     {
         return lhs.data()!=rhs.data();
     }
 
-    template<class ReprType, int Exponent>
+    template<class Rep, int Exponent>
     constexpr bool operator<(
-            const fixed_point<ReprType, Exponent>& lhs,
-            const fixed_point<ReprType, Exponent>& rhs)
+            const fixed_point<Rep, Exponent>& lhs,
+            const fixed_point<Rep, Exponent>& rhs)
     {
         return lhs.data()<rhs.data();
     }
 
-    template<class ReprType, int Exponent>
+    template<class Rep, int Exponent>
     constexpr bool operator>(
-            const fixed_point<ReprType, Exponent>& lhs,
-            const fixed_point<ReprType, Exponent>& rhs)
+            const fixed_point<Rep, Exponent>& lhs,
+            const fixed_point<Rep, Exponent>& rhs)
     {
         return lhs.data()>rhs.data();
     }
 
-    template<class ReprType, int Exponent>
+    template<class Rep, int Exponent>
     constexpr bool operator>=(
-            const fixed_point<ReprType, Exponent>& lhs,
-            const fixed_point<ReprType, Exponent>& rhs)
+            const fixed_point<Rep, Exponent>& lhs,
+            const fixed_point<Rep, Exponent>& rhs)
     {
         return lhs.data()>=rhs.data();
     }
 
-    template<class ReprType, int Exponent>
+    template<class Rep, int Exponent>
     constexpr bool operator<=(
-            const fixed_point<ReprType, Exponent>& lhs,
-            const fixed_point<ReprType, Exponent>& rhs)
+            const fixed_point<Rep, Exponent>& lhs,
+            const fixed_point<Rep, Exponent>& rhs)
     {
         return lhs.data()<=rhs.data();
     }
@@ -874,61 +874,61 @@ namespace sg14 {
     // (fixed_point @ fixed_point) arithmetic operators
 
     // negate
-    template<class RhsReprType, int RhsExponent>
-    constexpr auto operator-(const fixed_point<RhsReprType, RhsExponent>& rhs)
+    template<class RhsRep, int RhsExponent>
+    constexpr auto operator-(const fixed_point<RhsRep, RhsExponent>& rhs)
     -> typename _fixed_point_impl::default_arithmetic_policy::negate<
-            fixed_point<RhsReprType, RhsExponent>>::result_type
+            fixed_point<RhsRep, RhsExponent>>::result_type
     {
         return _fixed_point_impl::policy_negate<_fixed_point_impl::default_arithmetic_policy>(rhs);
     }
 
     template<
-            class LhsReprType, int LhsExponent,
-            class RhsReprType, int RhsExponent>
+            class LhsRep, int LhsExponent,
+            class RhsRep, int RhsExponent>
     constexpr auto operator+(
-            const fixed_point<LhsReprType, LhsExponent>& lhs,
-            const fixed_point<RhsReprType, RhsExponent>& rhs)
+            const fixed_point<LhsRep, LhsExponent>& lhs,
+            const fixed_point<RhsRep, RhsExponent>& rhs)
     -> typename _fixed_point_impl::default_arithmetic_policy::add<
-            fixed_point<LhsReprType, LhsExponent>,
-            fixed_point<RhsReprType, RhsExponent>>::result_type
+            fixed_point<LhsRep, LhsExponent>,
+            fixed_point<RhsRep, RhsExponent>>::result_type
     {
         return _fixed_point_impl::policy_add<_fixed_point_impl::default_arithmetic_policy>(lhs, rhs);
     }
 
     template<
-            class LhsReprType, int LhsExponent,
-            class RhsReprType, int RhsExponent>
+            class LhsRep, int LhsExponent,
+            class RhsRep, int RhsExponent>
     constexpr auto operator-(
-            const fixed_point<LhsReprType, LhsExponent>& lhs,
-            const fixed_point<RhsReprType, RhsExponent>& rhs)
+            const fixed_point<LhsRep, LhsExponent>& lhs,
+            const fixed_point<RhsRep, RhsExponent>& rhs)
     -> typename _fixed_point_impl::default_arithmetic_policy::subtract<
-            fixed_point<LhsReprType, LhsExponent>,
-            fixed_point<RhsReprType, RhsExponent>>::result_type
+            fixed_point<LhsRep, LhsExponent>,
+            fixed_point<RhsRep, RhsExponent>>::result_type
     {
         return _fixed_point_impl::policy_subtract<_fixed_point_impl::default_arithmetic_policy>(lhs, rhs);
     }
 
     // fixed-point, fixed-point -> fixed-point
     template<
-            class LhsReprType, int LhsExponent,
-            class RhsReprType, int RhsExponent>
+            class LhsRep, int LhsExponent,
+            class RhsRep, int RhsExponent>
     constexpr auto operator*(
-            const fixed_point<LhsReprType, LhsExponent>& lhs,
-            const fixed_point<RhsReprType, RhsExponent>& rhs)
+            const fixed_point<LhsRep, LhsExponent>& lhs,
+            const fixed_point<RhsRep, RhsExponent>& rhs)
     -> typename _fixed_point_impl::default_arithmetic_policy::multiply<
-            fixed_point<LhsReprType, LhsExponent>,
-            fixed_point<RhsReprType, RhsExponent>>::result_type
+            fixed_point<LhsRep, LhsExponent>,
+            fixed_point<RhsRep, RhsExponent>>::result_type
     {
         return _fixed_point_impl::policy_multiply<_fixed_point_impl::default_arithmetic_policy>(lhs, rhs);
     }
 
-    template<class LhsReprType, int LhsExponent, class RhsReprType, int RhsExponent>
+    template<class LhsRep, int LhsExponent, class RhsRep, int RhsExponent>
     constexpr auto operator/(
-            const fixed_point<LhsReprType, LhsExponent>& lhs,
-            const fixed_point<RhsReprType, RhsExponent>& rhs)
+            const fixed_point<LhsRep, LhsExponent>& lhs,
+            const fixed_point<RhsRep, RhsExponent>& rhs)
     -> typename _fixed_point_impl::default_arithmetic_policy::divide<
-            fixed_point<LhsReprType, LhsExponent>,
-            fixed_point<RhsReprType, RhsExponent>>::result_type
+            fixed_point<LhsRep, LhsExponent>,
+            fixed_point<RhsRep, RhsExponent>>::result_type
     {
         return _fixed_point_impl::policy_divide<_fixed_point_impl::default_arithmetic_policy>(lhs, rhs);
     }
@@ -1017,126 +1017,126 @@ namespace sg14 {
 
     // fixed-point, integer -> fixed-point
     template<
-            class ReprType, int Exponent,
+            class Rep, int Exponent,
             class Integer,
             typename = typename std::enable_if<is_integral<Integer>::value>::type>
-    constexpr auto operator*(const fixed_point<ReprType, Exponent>& lhs, const Integer& rhs)
-    -> fixed_point<decltype(std::declval<ReprType>()*std::declval<Integer>()), Exponent>
+    constexpr auto operator*(const fixed_point<Rep, Exponent>& lhs, const Integer& rhs)
+    -> fixed_point<decltype(std::declval<Rep>()*std::declval<Integer>()), Exponent>
     {
-        using repr_type = fixed_point<decltype(std::declval<ReprType>()*std::declval<Integer>()), Exponent>;
+        using repr_type = fixed_point<decltype(std::declval<Rep>()*std::declval<Integer>()), Exponent>;
         return multiply<repr_type>(lhs, fixed_point<Integer>(rhs));
     }
 
     template<
-            class ReprType, int Exponent,
+            class Rep, int Exponent,
             class Integer,
             typename = typename std::enable_if<is_integral<Integer>::value>::type>
-    constexpr auto operator/(const fixed_point<ReprType, Exponent>& lhs, const Integer& rhs)
-    -> fixed_point<decltype(std::declval<ReprType>()/std::declval<Integer>()), Exponent>
+    constexpr auto operator/(const fixed_point<Rep, Exponent>& lhs, const Integer& rhs)
+    -> fixed_point<decltype(std::declval<Rep>()/std::declval<Integer>()), Exponent>
     {
-        using result_type = fixed_point<decltype(std::declval<ReprType>()/std::declval<Integer>()), Exponent>;
+        using result_type = fixed_point<decltype(std::declval<Rep>()/std::declval<Integer>()), Exponent>;
         return divide<result_type>(lhs, fixed_point<Integer>(rhs));
     }
 
     // integer. fixed-point -> fixed-point
     template<
             class Integer,
-            class ReprType, int Exponent,
+            class Rep, int Exponent,
             typename = typename std::enable_if<is_integral<Integer>::value>::type>
-    constexpr auto operator*(const Integer& lhs, const fixed_point<ReprType, Exponent>& rhs)
-    -> fixed_point<decltype(std::declval<Integer>()*std::declval<ReprType>()), Exponent>
+    constexpr auto operator*(const Integer& lhs, const fixed_point<Rep, Exponent>& rhs)
+    -> fixed_point<decltype(std::declval<Integer>()*std::declval<Rep>()), Exponent>
     {
-        using result_type = fixed_point<decltype(std::declval<Integer>()*std::declval<ReprType>()), Exponent>;
+        using result_type = fixed_point<decltype(std::declval<Integer>()*std::declval<Rep>()), Exponent>;
         return multiply<result_type>(fixed_point<Integer>(lhs), rhs);
     }
 
     template<
             class Integer,
-            class ReprType, int Exponent,
+            class Rep, int Exponent,
             typename = typename std::enable_if<is_integral<Integer>::value>::type>
-    constexpr auto operator/(const Integer& lhs, const fixed_point<ReprType, Exponent>& rhs)
-    -> fixed_point<decltype(std::declval<Integer>()/std::declval<ReprType>()), Exponent>
+    constexpr auto operator/(const Integer& lhs, const fixed_point<Rep, Exponent>& rhs)
+    -> fixed_point<decltype(std::declval<Integer>()/std::declval<Rep>()), Exponent>
     {
-        using result_type = fixed_point<decltype(std::declval<Integer>()/std::declval<ReprType>()), Exponent>;
+        using result_type = fixed_point<decltype(std::declval<Integer>()/std::declval<Rep>()), Exponent>;
         return divide<result_type>(fixed_point<Integer>(lhs), rhs);
     }
 
     // fixed-point, floating-point -> floating-point
-    template<class LhsReprType, int LhsExponent, class Float>
+    template<class LhsRep, int LhsExponent, class Float>
     constexpr auto operator*(
-            const fixed_point<LhsReprType, LhsExponent>& lhs,
+            const fixed_point<LhsRep, LhsExponent>& lhs,
             const Float& rhs)
     -> _fixed_point_impl::common_type_t<
-            fixed_point<LhsReprType, LhsExponent>,
+            fixed_point<LhsRep, LhsExponent>,
             typename std::enable_if<std::is_floating_point<Float>::value, Float>::type>
     {
-        using result_type = _fixed_point_impl::common_type_t<fixed_point<LhsReprType, LhsExponent>, Float>;
+        using result_type = _fixed_point_impl::common_type_t<fixed_point<LhsRep, LhsExponent>, Float>;
         return static_cast<result_type>(lhs)*rhs;
     }
 
-    template<class LhsReprType, int LhsExponent, class Float>
+    template<class LhsRep, int LhsExponent, class Float>
     constexpr auto operator/(
-            const fixed_point<LhsReprType, LhsExponent>& lhs,
+            const fixed_point<LhsRep, LhsExponent>& lhs,
             const Float& rhs)
     -> _fixed_point_impl::common_type_t<
-            fixed_point<LhsReprType, LhsExponent>,
+            fixed_point<LhsRep, LhsExponent>,
             typename std::enable_if<std::is_floating_point<Float>::value, Float>::type>
     {
-        using result_type = _fixed_point_impl::common_type_t<fixed_point<LhsReprType, LhsExponent>, Float>;
+        using result_type = _fixed_point_impl::common_type_t<fixed_point<LhsRep, LhsExponent>, Float>;
         return static_cast<result_type>(lhs)/rhs;
     }
 
     // floating-point, fixed-point -> floating-point
-    template<class Float, class RhsReprType, int RhsExponent>
+    template<class Float, class RhsRep, int RhsExponent>
     constexpr auto operator*(
             const Float& lhs,
-            const fixed_point<RhsReprType, RhsExponent>& rhs)
+            const fixed_point<RhsRep, RhsExponent>& rhs)
     -> _fixed_point_impl::common_type_t<
             typename std::enable_if<std::is_floating_point<Float>::value, Float>::type,
-            fixed_point<RhsReprType, RhsExponent>>
+            fixed_point<RhsRep, RhsExponent>>
     {
-        using result_type = _fixed_point_impl::common_type_t<fixed_point<RhsReprType, RhsExponent>, Float>;
+        using result_type = _fixed_point_impl::common_type_t<fixed_point<RhsRep, RhsExponent>, Float>;
         return lhs*static_cast<result_type>(rhs);
     }
 
-    template<class Float, class RhsReprType, int RhsExponent>
+    template<class Float, class RhsRep, int RhsExponent>
     constexpr auto operator/(
             const Float& lhs,
-            const fixed_point<RhsReprType, RhsExponent>& rhs)
+            const fixed_point<RhsRep, RhsExponent>& rhs)
     -> _fixed_point_impl::common_type_t<
             typename std::enable_if<std::is_floating_point<Float>::value, Float>::type,
-            fixed_point<RhsReprType, RhsExponent>>
+            fixed_point<RhsRep, RhsExponent>>
     {
-        using result_type = _fixed_point_impl::common_type_t<fixed_point<RhsReprType, RhsExponent>, Float>;
+        using result_type = _fixed_point_impl::common_type_t<fixed_point<RhsRep, RhsExponent>, Float>;
         return lhs/
                 static_cast<result_type>(rhs);
     }
 
-    template<class LhsReprType, int Exponent, class Rhs>
-    fixed_point<LhsReprType, Exponent>& operator+=(fixed_point<LhsReprType, Exponent>& lhs, const Rhs& rhs)
+    template<class LhsRep, int Exponent, class Rhs>
+    fixed_point<LhsRep, Exponent>& operator+=(fixed_point<LhsRep, Exponent>& lhs, const Rhs& rhs)
     {
-        return lhs = lhs+fixed_point<LhsReprType, Exponent>(rhs);
+        return lhs = lhs+fixed_point<LhsRep, Exponent>(rhs);
     }
 
-    template<class LhsReprType, int Exponent, class Rhs>
-    fixed_point<LhsReprType, Exponent>& operator-=(fixed_point<LhsReprType, Exponent>& lhs, const Rhs& rhs)
+    template<class LhsRep, int Exponent, class Rhs>
+    fixed_point<LhsRep, Exponent>& operator-=(fixed_point<LhsRep, Exponent>& lhs, const Rhs& rhs)
     {
-        return lhs = lhs-fixed_point<LhsReprType, Exponent>(rhs);
+        return lhs = lhs-fixed_point<LhsRep, Exponent>(rhs);
     }
 
-    template<class LhsReprType, int Exponent>
+    template<class LhsRep, int Exponent>
     template<class Rhs, typename std::enable_if<std::is_arithmetic<Rhs>::value, int>::type Dummy>
-    fixed_point<LhsReprType, Exponent>&
-    fixed_point<LhsReprType, Exponent>::operator*=(const Rhs& rhs)
+    fixed_point<LhsRep, Exponent>&
+    fixed_point<LhsRep, Exponent>::operator*=(const Rhs& rhs)
     {
         _repr *= static_cast<repr_type>(rhs);
         return *this;
     }
 
-    template<class LhsReprType, int Exponent>
+    template<class LhsRep, int Exponent>
     template<class Rhs, typename std::enable_if<std::is_arithmetic<Rhs>::value, int>::type Dummy>
-    fixed_point<LhsReprType, Exponent>&
-    fixed_point<LhsReprType, Exponent>::operator/=(const Rhs& rhs)
+    fixed_point<LhsRep, Exponent>&
+    fixed_point<LhsRep, Exponent>::operator/=(const Rhs& rhs)
     {
         _repr /= static_cast<repr_type>(rhs);
         return *this;

--- a/include/sg14/fixed_point.h
+++ b/include/sg14/fixed_point.h
@@ -289,7 +289,7 @@ namespace sg14 {
     private:
         // constructor taking representation explicitly using operator++(int)-style trick
         constexpr fixed_point(repr_type repr, int)
-                :_repr(repr)
+                :_r(repr)
         {
         }
 
@@ -300,21 +300,21 @@ namespace sg14 {
         /// constructor taking an integer type
         template<class S, typename std::enable_if<is_integral<S>::value, int>::type Dummy = 0>
         explicit constexpr fixed_point(S s)
-                :_repr(integral_to_repr(s))
+                :_r(integral_to_repr(s))
         {
         }
 
         /// constructor taking a floating-point type
         template<class S, typename std::enable_if<std::is_floating_point<S>::value, int>::type Dummy = 0>
         explicit constexpr fixed_point(S s)
-                :_repr(floating_point_to_repr(s))
+                :_r(floating_point_to_repr(s))
         {
         }
 
         /// constructor taking a fixed-point type
         template<class FromRep, int FromExponent>
         explicit constexpr fixed_point(const fixed_point<FromRep, FromExponent>& rhs)
-                :_repr(fixed_point_to_repr(rhs))
+                :_r(fixed_point_to_repr(rhs))
         {
         }
 
@@ -322,7 +322,7 @@ namespace sg14 {
         template<class S, typename std::enable_if<is_integral<S>::value, int>::type Dummy = 0>
         fixed_point& operator=(S s)
         {
-            _repr = integral_to_repr(s);
+            _r = integral_to_repr(s);
             return *this;
         }
 
@@ -330,7 +330,7 @@ namespace sg14 {
         template<class S, typename std::enable_if<std::is_floating_point<S>::value, int>::type Dummy = 0>
         fixed_point& operator=(S s)
         {
-            _repr = floating_point_to_repr(s);
+            _r = floating_point_to_repr(s);
             return *this;
         }
 
@@ -338,7 +338,7 @@ namespace sg14 {
         template<class FromRep, int FromExponent>
         fixed_point& operator=(const fixed_point<FromRep, FromExponent>& rhs)
         {
-            _repr = fixed_point_to_repr(rhs);
+            _r = fixed_point_to_repr(rhs);
             return *this;
         }
 
@@ -346,20 +346,20 @@ namespace sg14 {
         template<class S, typename std::enable_if<is_integral<S>::value, int>::type Dummy = 0>
         explicit constexpr operator S() const
         {
-            return repr_to_integral<S>(_repr);
+            return repr_to_integral<S>(_r);
         }
 
         /// returns value represented as floating-point
         template<class S, typename std::enable_if<std::is_floating_point<S>::value, int>::type Dummy = 0>
         explicit constexpr operator S() const
         {
-            return repr_to_floating_point<S>(_repr);
+            return repr_to_floating_point<S>(_r);
         }
 
         /// returns non-zeroness represented as boolean
         explicit constexpr operator bool() const
         {
-            return _repr!=0;
+            return _r!=0;
         }
 
         template<class Rhs, typename std::enable_if<std::is_arithmetic<Rhs>::value, int>::type Dummy = 0>
@@ -371,7 +371,7 @@ namespace sg14 {
         /// returns internal representation of value
         constexpr repr_type data() const
         {
-            return _repr;
+            return _r;
         }
 
         /// creates an instance given the underlying representation value
@@ -439,7 +439,7 @@ namespace sg14 {
         ////////////////////////////////////////////////////////////////////////////////
         // variables
 
-        repr_type _repr;
+        repr_type _r;
     };
 
     /// \brief Produce a fixed-point type with the given number of integer and fractional digits.
@@ -1129,7 +1129,7 @@ namespace sg14 {
     fixed_point<LhsRep, Exponent>&
     fixed_point<LhsRep, Exponent>::operator*=(const Rhs& rhs)
     {
-        _repr *= static_cast<repr_type>(rhs);
+        _r *= static_cast<repr_type>(rhs);
         return *this;
     }
 
@@ -1138,7 +1138,7 @@ namespace sg14 {
     fixed_point<LhsRep, Exponent>&
     fixed_point<LhsRep, Exponent>::operator/=(const Rhs& rhs)
     {
-        _repr /= static_cast<repr_type>(rhs);
+        _r /= static_cast<repr_type>(rhs);
         return *this;
     }
 }

--- a/include/sg14/fixed_point.h
+++ b/include/sg14/fixed_point.h
@@ -300,21 +300,21 @@ namespace sg14 {
         /// constructor taking an integer type
         template<class S, typename std::enable_if<is_integral<S>::value, int>::type Dummy = 0>
         explicit constexpr fixed_point(S s)
-                :_r(integral_to_repr(s))
+                :_r(integral_to_rep(s))
         {
         }
 
         /// constructor taking a floating-point type
         template<class S, typename std::enable_if<std::is_floating_point<S>::value, int>::type Dummy = 0>
         explicit constexpr fixed_point(S s)
-                :_r(floating_point_to_repr(s))
+                :_r(floating_point_to_rep(s))
         {
         }
 
         /// constructor taking a fixed-point type
         template<class FromRep, int FromExponent>
         explicit constexpr fixed_point(const fixed_point<FromRep, FromExponent>& rhs)
-                :_r(fixed_point_to_repr(rhs))
+                :_r(fixed_point_to_rep(rhs))
         {
         }
 
@@ -322,7 +322,7 @@ namespace sg14 {
         template<class S, typename std::enable_if<is_integral<S>::value, int>::type Dummy = 0>
         fixed_point& operator=(S s)
         {
-            _r = integral_to_repr(s);
+            _r = integral_to_rep(s);
             return *this;
         }
 
@@ -330,7 +330,7 @@ namespace sg14 {
         template<class S, typename std::enable_if<std::is_floating_point<S>::value, int>::type Dummy = 0>
         fixed_point& operator=(S s)
         {
-            _r = floating_point_to_repr(s);
+            _r = floating_point_to_rep(s);
             return *this;
         }
 
@@ -338,7 +338,7 @@ namespace sg14 {
         template<class FromRep, int FromExponent>
         fixed_point& operator=(const fixed_point<FromRep, FromExponent>& rhs)
         {
-            _r = fixed_point_to_repr(rhs);
+            _r = fixed_point_to_rep(rhs);
             return *this;
         }
 
@@ -346,14 +346,14 @@ namespace sg14 {
         template<class S, typename std::enable_if<is_integral<S>::value, int>::type Dummy = 0>
         explicit constexpr operator S() const
         {
-            return repr_to_integral<S>(_r);
+            return rep_to_integral<S>(_r);
         }
 
         /// returns value represented as floating-point
         template<class S, typename std::enable_if<std::is_floating_point<S>::value, int>::type Dummy = 0>
         explicit constexpr operator S() const
         {
-            return repr_to_floating_point<S>(_r);
+            return rep_to_floating_point<S>(_r);
         }
 
         /// returns non-zeroness represented as boolean
@@ -390,7 +390,7 @@ namespace sg14 {
         template<class S, typename std::enable_if<is_integral<S>::value, int>::type Dummy = 0>
         static constexpr S one()
         {
-            return integral_to_repr<S>(1);
+            return integral_to_rep<S>(1);
         }
 
         template<class S>
@@ -401,7 +401,7 @@ namespace sg14 {
         }
 
         template<class S>
-        static constexpr rep integral_to_repr(S s)
+        static constexpr rep integral_to_rep(S s)
         {
             static_assert(is_integral<S>::value, "S must be unsigned integral type");
 
@@ -409,7 +409,7 @@ namespace sg14 {
         }
 
         template<class S>
-        static constexpr S repr_to_integral(rep r)
+        static constexpr S rep_to_integral(rep r)
         {
             static_assert(is_integral<S>::value, "S must be unsigned integral type");
 
@@ -417,21 +417,21 @@ namespace sg14 {
         }
 
         template<class S>
-        static constexpr rep floating_point_to_repr(S s)
+        static constexpr rep floating_point_to_rep(S s)
         {
             static_assert(std::is_floating_point<S>::value, "S must be floating-point type");
             return static_cast<rep>(s*one<S>());
         }
 
         template<class S>
-        static constexpr S repr_to_floating_point(rep r)
+        static constexpr S rep_to_floating_point(rep r)
         {
             static_assert(std::is_floating_point<S>::value, "S must be floating-point type");
             return S(r)*inverse_one<S>();
         }
 
         template<class FromRep, int FromExponent>
-        static constexpr rep fixed_point_to_repr(const fixed_point<FromRep, FromExponent>& rhs)
+        static constexpr rep fixed_point_to_rep(const fixed_point<FromRep, FromExponent>& rhs)
         {
             return _fixed_point_impl::shift_right<(exponent-FromExponent), rep>(rhs.data());
         }
@@ -698,13 +698,13 @@ namespace sg14 {
         // arithmetic result types
 
         template<typename LhsFixedPoint, typename RhsFixedPoint>
-        using subtract_result_repr = typename make_signed<typename sg14::common_type<LhsFixedPoint, RhsFixedPoint>::type>::type;
+        using subtract_result_rep = typename make_signed<typename sg14::common_type<LhsFixedPoint, RhsFixedPoint>::type>::type;
 
         template<typename Rep>
-        using square_result_repr = typename make_unsigned<Rep>::type;
+        using square_result_rep = typename make_unsigned<Rep>::type;
 
         template<typename FixedPoint>
-        using sqrt_result_repr = typename make_unsigned<FixedPoint>::type;
+        using sqrt_result_rep = typename make_unsigned<FixedPoint>::type;
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/src/common/fixed_point.natvis
+++ b/src/common/fixed_point.natvis
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
  <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
    <Type Name="sg14::integer&lt;*&gt;">
-     <DisplayString>{repr+0}</DisplayString>
+     <DisplayString>{_r+0}</DisplayString>
    </Type>
 
    <!--<Type Name="sg14::fixed_point&lt;*&gt;">

--- a/src/common/fixed_point.natvis
+++ b/src/common/fixed_point.natvis
@@ -5,9 +5,9 @@
    </Type>
 
    <!--<Type Name="sg14::fixed_point&lt;*&gt;">
-     <DisplayString>{_repr}</DisplayString>
+     <DisplayString>{_r}</DisplayString>
      <Expand>
-       <Item Name="_repr">_repr</Item>
+       <Item Name="_r">_r</Item>
        <Item Name="exponent">exponent</Item>
        <Item Name="digits">digits</Item>
        <Item Name="integer_digits">integer_digits</Item>
@@ -16,14 +16,14 @@
    </Type>-->
    
    <Type Name="sg14::fixed_point&lt;*&gt;">
-     <DisplayString Condition="exponent==0 &amp;&amp; _repr*0-1&lt;0"  >{(long double)_repr} u{integer_digits}:{fractional_digits}</DisplayString>
-     <DisplayString Condition="exponent==0 &amp;&amp; _repr*0-1&gt;0"  >{(long double)_repr} s{integer_digits}:{fractional_digits}</DisplayString>
-     <DisplayString Condition="exponent&lt;0 &amp;&amp; _repr*0-1&lt;0">{(long double)_repr/(1&lt;&lt;-exponent)} u{integer_digits}:{fractional_digits}</DisplayString>
-     <DisplayString Condition="exponent&lt;0 &amp;&amp; _repr*0-1&gt;0">{(long double)_repr/(1&lt;&lt;-exponent)} s{integer_digits}:{fractional_digits}</DisplayString>
-     <DisplayString Condition="exponent&gt;0 &amp;&amp; _repr*0-1&lt;0">{(long double)_repr*(1&lt;&lt;+exponent)} u{integer_digits}:{fractional_digits}</DisplayString>
-     <DisplayString Condition="exponent&gt;0 &amp;&amp; _repr*0-1&gt;0">{(long double)_repr*(1&lt;&lt;+exponent)} s{integer_digits}:{fractional_digits}</DisplayString>
+     <DisplayString Condition="exponent==0 &amp;&amp; _r*0-1&lt;0"  >{(long double)_r} u{integer_digits}:{fractional_digits}</DisplayString>
+     <DisplayString Condition="exponent==0 &amp;&amp; _r*0-1&gt;0"  >{(long double)_r} s{integer_digits}:{fractional_digits}</DisplayString>
+     <DisplayString Condition="exponent&lt;0 &amp;&amp; _r*0-1&lt;0">{(long double)_r/(1&lt;&lt;-exponent)} u{integer_digits}:{fractional_digits}</DisplayString>
+     <DisplayString Condition="exponent&lt;0 &amp;&amp; _r*0-1&gt;0">{(long double)_r/(1&lt;&lt;-exponent)} s{integer_digits}:{fractional_digits}</DisplayString>
+     <DisplayString Condition="exponent&gt;0 &amp;&amp; _r*0-1&lt;0">{(long double)_r*(1&lt;&lt;+exponent)} u{integer_digits}:{fractional_digits}</DisplayString>
+     <DisplayString Condition="exponent&gt;0 &amp;&amp; _r*0-1&gt;0">{(long double)_r*(1&lt;&lt;+exponent)} s{integer_digits}:{fractional_digits}</DisplayString>
      <Expand>
-       <Item Name="_repr">_repr</Item>
+       <Item Name="_r">_r</Item>
        <Item Name="exponent">exponent</Item>
        <Item Name="digits">digits</Item>
        <Item Name="integer_digits">integer_digits</Item>

--- a/src/test/elastic_common.h
+++ b/src/test/elastic_common.h
@@ -252,7 +252,7 @@ struct positive_elastic_test {
 
     static_assert(sg14::is_elastic<elastic_type>::value, "sg14::is_elastic test failed");
     static_assert(!sg14::is_elastic<fixed_point_type>::value, "sg14::is_elastic test failed");
-    static_assert(!sg14::is_elastic<typename fixed_point_type::repr_type>::value, "sg14::is_elastic test failed");
+    static_assert(!sg14::is_elastic<typename fixed_point_type::rep>::value, "sg14::is_elastic test failed");
 
     static_assert(sg14::is_signed<elastic_type>::value==sg14::is_signed<fixed_point_type>::value,
             "signedness of elastic type differns from underlying fixed-point type");
@@ -277,7 +277,7 @@ struct positive_elastic_test {
 
     static_assert(sg14::is_elastic<elastic_type>::value, "sg14::is_elastic test failed");
     static_assert(!sg14::is_elastic<fixed_point_type>::value, "sg14::is_elastic test failed");
-    static_assert(!sg14::is_elastic<typename fixed_point_type::repr_type>::value, "sg14::is_elastic test failed");
+    static_assert(!sg14::is_elastic<typename fixed_point_type::rep>::value, "sg14::is_elastic test failed");
 
     static_assert(sg14::is_signed<elastic_type>::value==sg14::is_signed<fixed_point_type>::value,
             "signedness of elastic type differns from underlying fixed-point type");

--- a/src/test/fixed_point_built_in.cpp
+++ b/src/test/fixed_point_built_in.cpp
@@ -12,7 +12,7 @@
 #define TEST_LABEL built_in_
 
 ////////////////////////////////////////////////////////////////////////////////
-// integer types used as fixed_point Repr type
+// integer types used as fixed_point Rep type
 
 using test_int = int;
 

--- a/src/test/fixed_point_common.h
+++ b/src/test/fixed_point_common.h
@@ -49,8 +49,8 @@ namespace _impl {
     using namespace sg14::_fixed_point_impl;
 }
 
-template <typename ReprType=test_int, int Exponent=0>
-using fixed_point = sg14::fixed_point<ReprType, Exponent>;
+template <typename Rep=test_int, int Exponent=0>
+using fixed_point = sg14::fixed_point<Rep, Exponent>;
 
 template<int IntegerDigits, int FractionalDigits = 0, class Archetype = test_signed>
 using make_fixed = sg14::make_fixed<IntegerDigits, FractionalDigits, Archetype>;
@@ -665,13 +665,13 @@ static_assert(y == 5.75, "usage test failed");
 ////////////////////////////////////////////////////////////////////////////////
 // FixedPointTester
 
-template <class ReprType, int Exponent>
+template <class Rep, int Exponent>
 struct FixedPointTester {
-    using fixed_point = ::fixed_point<ReprType, Exponent>;
+    using fixed_point = ::fixed_point<Rep, Exponent>;
 
-    // ReprType
-    using repr_type = ReprType;
-    static_assert(sizeof(repr_type) == sizeof(fixed_point), "fixed_point must be the same size as its ReprType");
+    // Rep
+    using repr_type = Rep;
+    static_assert(sizeof(repr_type) == sizeof(fixed_point), "fixed_point must be the same size as its Rep");
     static_assert(
             is_same<repr_type, typename fixed_point::repr_type>::value,
             "mismatched repr_type");    // possibly overly restrictive (e.g. hardware-specific specializations)
@@ -686,7 +686,7 @@ struct FixedPointTester {
     // simply assignment to and from underlying representation
     using numeric_limits = std::numeric_limits<fixed_point>;
     static constexpr fixed_point min = fixed_point::from_data(repr_type(1));
-    static_assert(min.data() == repr_type(1), "all ReprType types should be able to store the number 1!");
+    static_assert(min.data() == repr_type(1), "all Rep types should be able to store the number 1!");
 
     // sg14::_impl::widen_integer_result_t
     static_assert(
@@ -714,9 +714,9 @@ struct FixedPointTester {
     static_assert(is_same<
                     _impl::common_type_t<fixed_point>,
                     ::fixed_point<
-                            typename sg14::common_type<ReprType>::type,
+                            typename sg14::common_type<Rep>::type,
                             Exponent>>::value,
-            "a fixed point specialization follows the same implicit promotion rules as its ReprType");
+            "a fixed point specialization follows the same implicit promotion rules as its Rep");
 
     static_assert(
             is_same<
@@ -729,7 +729,7 @@ struct FixedPointTester {
             is_same<
                     fixed_point,
                     _impl::common_type_t<fixed_point, fixed_point>>::value,
-            "a fixed point specialization follows the same implicit promotion rules as its ReprType");
+            "a fixed point specialization follows the same implicit promotion rules as its Rep");
 
     // for convenience, fixed_point API assumes binary and unary homogeneous common_types are the same
     static_assert(
@@ -743,12 +743,12 @@ struct FixedPointTester {
             is_same<
                     decltype(min + min),
                     ::fixed_point<decltype(declval<repr_type>() + declval<repr_type>()), exponent>>::value,
-            "promotion rule for addition fixed_point<ReprType> should match its ReprType");
+            "promotion rule for addition fixed_point<Rep> should match its Rep");
     static_assert(
             is_same<
                     decltype(min - min),
                     ::fixed_point<decltype(declval<repr_type>() - declval<repr_type>()), exponent>>::value,
-            "promotion rule for subtraction fixed_point<ReprType> should match its ReprType");
+            "promotion rule for subtraction fixed_point<Rep> should match its Rep");
 
     // assorted tests of +, -, * and /
     static_assert(min + min == 2 * min, "basic arithmetic isn't working");
@@ -757,27 +757,27 @@ struct FixedPointTester {
 #endif
 };
 
-template <typename ReprType>
-struct FixedPointReprTypeTester {
-    FixedPointTester<ReprType, -100> _0;
-    FixedPointTester<ReprType, -10> _1;
-    FixedPointTester<ReprType, -1> _2;
-    FixedPointTester<ReprType, 0> _3;
-    FixedPointTester<ReprType, 1> _4;
-    FixedPointTester<ReprType, 10> _5;
-    FixedPointTester<ReprType, 100> _6;
+template <typename Rep>
+struct FixedPointRepTester {
+    FixedPointTester<Rep, -100> _0;
+    FixedPointTester<Rep, -10> _1;
+    FixedPointTester<Rep, -1> _2;
+    FixedPointTester<Rep, 0> _3;
+    FixedPointTester<Rep, 1> _4;
+    FixedPointTester<Rep, 10> _5;
+    FixedPointTester<Rep, 100> _6;
 };
 
-template struct FixedPointReprTypeTester<int8>;
-template struct FixedPointReprTypeTester<uint8>;
+template struct FixedPointRepTester<int8>;
+template struct FixedPointRepTester<uint8>;
 
-template struct FixedPointReprTypeTester<int16>;
-template struct FixedPointReprTypeTester<uint16>;
+template struct FixedPointRepTester<int16>;
+template struct FixedPointRepTester<uint16>;
 
-template struct FixedPointReprTypeTester<int32>;
-template struct FixedPointReprTypeTester<uint32>;
+template struct FixedPointRepTester<int32>;
+template struct FixedPointRepTester<uint32>;
 
 #if defined(_GLIBCXX_USE_INT128)
-template struct FixedPointReprTypeTester<int64>;
-template struct FixedPointReprTypeTester<uint64>;
+template struct FixedPointRepTester<int64>;
+template struct FixedPointRepTester<uint64>;
 #endif

--- a/src/test/fixed_point_common.h
+++ b/src/test/fixed_point_common.h
@@ -670,11 +670,11 @@ struct FixedPointTester {
     using fixed_point = ::fixed_point<Rep, Exponent>;
 
     // Rep
-    using repr_type = Rep;
-    static_assert(sizeof(repr_type) == sizeof(fixed_point), "fixed_point must be the same size as its Rep");
+    using rep = Rep;
+    static_assert(sizeof(rep) == sizeof(fixed_point), "fixed_point must be the same size as its Rep");
     static_assert(
-            is_same<repr_type, typename fixed_point::repr_type>::value,
-            "mismatched repr_type");    // possibly overly restrictive (e.g. hardware-specific specializations)
+            is_same<rep, typename fixed_point::rep>::value,
+            "mismatched rep");    // possibly overly restrictive (e.g. hardware-specific specializations)
 
     // Exponent
     static constexpr int exponent = Exponent;
@@ -685,8 +685,8 @@ struct FixedPointTester {
 #if ! defined(_MSC_VER)
     // simply assignment to and from underlying representation
     using numeric_limits = std::numeric_limits<fixed_point>;
-    static constexpr fixed_point min = fixed_point::from_data(repr_type(1));
-    static_assert(min.data() == repr_type(1), "all Rep types should be able to store the number 1!");
+    static constexpr fixed_point min = fixed_point::from_data(rep(1));
+    static_assert(min.data() == rep(1), "all Rep types should be able to store the number 1!");
 
     // sg14::_impl::widen_integer_result_t
     static_assert(
@@ -742,12 +742,12 @@ struct FixedPointTester {
     static_assert(
             is_same<
                     decltype(min + min),
-                    ::fixed_point<decltype(declval<repr_type>() + declval<repr_type>()), exponent>>::value,
+                    ::fixed_point<decltype(declval<rep>() + declval<rep>()), exponent>>::value,
             "promotion rule for addition fixed_point<Rep> should match its Rep");
     static_assert(
             is_same<
                     decltype(min - min),
-                    ::fixed_point<decltype(declval<repr_type>() - declval<repr_type>()), exponent>>::value,
+                    ::fixed_point<decltype(declval<rep>() - declval<rep>()), exponent>>::value,
             "promotion rule for subtraction fixed_point<Rep> should match its Rep");
 
     // assorted tests of +, -, * and /

--- a/src/test/fixed_point_native_integer.cpp
+++ b/src/test/fixed_point_native_integer.cpp
@@ -16,7 +16,7 @@
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
-// integer types used as fixed_point Repr type
+// integer types used as fixed_point Rep type
 
 using test_int = sg14::native_integer<>;
 

--- a/src/test/fixed_point_saturated_integer.cpp
+++ b/src/test/fixed_point_saturated_integer.cpp
@@ -16,7 +16,7 @@
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
-// integer types used as fixed_point Repr type
+// integer types used as fixed_point Rep type
 
 using test_int = sg14::saturated_integer<>;
 

--- a/src/test/fixed_point_throwing_integer.cpp
+++ b/src/test/fixed_point_throwing_integer.cpp
@@ -21,7 +21,7 @@
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
-// integer types used as fixed_point Repr type
+// integer types used as fixed_point Rep type
 
 using test_int = sg14::throwing_integer<>;
 

--- a/src/test/integer.h
+++ b/src/test/integer.h
@@ -73,7 +73,7 @@ namespace sg14 {
     template <class Rhs> \
     auto operator OP (const Rhs& rhs) \
     -> integer& { \
-        _r = static_cast<repr_type>(_r BIN_OP rhs); \
+        _r = static_cast<rep>(_r BIN_OP rhs); \
         return *this; }
 
 #define _SG14_INTEGER_BIT_SHIFT_DEFINE(OP) \
@@ -299,7 +299,7 @@ namespace sg14 {
         ////////////////////////////////////////////////////////////////////////////////
         // types
 
-        using repr_type = Rep;
+        using rep = Rep;
         using overflow = OverflowPolicy;
 
         ////////////////////////////////////////////////////////////////////////////////
@@ -307,13 +307,13 @@ namespace sg14 {
 
         template<class RhsRep, typename std::enable_if<!_integer_impl::is_integer_class<RhsRep>::value, int>::type dummy = 0>
         constexpr explicit integer(const RhsRep& rhs)
-                :_r(OverflowPolicy{}.template convert<repr_type>(rhs))
+                :_r(OverflowPolicy{}.template convert<rep>(rhs))
         {
         }
 
         template<class Rhs, typename std::enable_if<_integer_impl::is_integer_class<Rhs>::value, int>::type dummy = 0>
         constexpr explicit integer(const Rhs& rhs)
-                :_r(OverflowPolicy{}.template convert<repr_type>(rhs.data()))
+                :_r(OverflowPolicy{}.template convert<rep>(rhs.data()))
         {
         }
 
@@ -336,7 +336,7 @@ namespace sg14 {
 
         _SG14_INTEGER_COMPOUND_ASSIGN_DEFINE(/=, /);
 
-        constexpr repr_type const& data() const
+        constexpr rep const& data() const
         {
             return _r;
         }
@@ -345,7 +345,7 @@ namespace sg14 {
         ////////////////////////////////////////////////////////////////////////////////
         // variables
 
-        repr_type _r;
+        rep _r;
     };
 
     _SG14_INTEGER_COMPARISON_DEFINE(==);
@@ -480,8 +480,8 @@ namespace std {
     struct numeric_limits<sg14::integer<Rep, OverflowPolicy>> {
         // integer-specific helpers
         using _value_type = sg14::integer<Rep, OverflowPolicy>;
-        using _repr_type = typename _value_type::repr_type;
-        using _repr_numeric_limits = numeric_limits<_repr_type>;
+        using _rep = typename _value_type::rep;
+        using _repr_numeric_limits = numeric_limits<_rep>;
 
         // standard members
 

--- a/src/test/integer.h
+++ b/src/test/integer.h
@@ -481,7 +481,7 @@ namespace std {
         // integer-specific helpers
         using _value_type = sg14::integer<Rep, OverflowPolicy>;
         using _rep = typename _value_type::rep;
-        using _repr_numeric_limits = numeric_limits<_rep>;
+        using _rep_numeric_limits = numeric_limits<_rep>;
 
         // standard members
 
@@ -489,84 +489,84 @@ namespace std {
 
         static constexpr _value_type min() noexcept
         {
-            return _value_type(_repr_numeric_limits::min());
+            return _value_type(_rep_numeric_limits::min());
         }
 
         static constexpr _value_type max() noexcept
         {
-            return _value_type(_repr_numeric_limits::max());
+            return _value_type(_rep_numeric_limits::max());
         }
 
         static constexpr _value_type lowest() noexcept
         {
-            return _value_type(_repr_numeric_limits::lowest());
+            return _value_type(_rep_numeric_limits::lowest());
         }
 
-        static constexpr int digits = _repr_numeric_limits::digits;
+        static constexpr int digits = _rep_numeric_limits::digits;
 
-        static constexpr int digits10 = _repr_numeric_limits::digits10;
-        static constexpr int max_digits10 = _repr_numeric_limits::max_digits10;
+        static constexpr int digits10 = _rep_numeric_limits::digits10;
+        static constexpr int max_digits10 = _rep_numeric_limits::max_digits10;
 
-        static constexpr bool is_signed = _repr_numeric_limits::is_signed;
+        static constexpr bool is_signed = _rep_numeric_limits::is_signed;
 
         static constexpr bool is_integer = true;
         static_assert(is_integer, "integer must be represented using binary type");
 
-        static constexpr bool is_exact = _repr_numeric_limits::is_exact;
+        static constexpr bool is_exact = _rep_numeric_limits::is_exact;
 
-        static constexpr int radix = _repr_numeric_limits::radix;
+        static constexpr int radix = _rep_numeric_limits::radix;
         static_assert(radix==2, "integer must be represented using binary type");
 
         static constexpr _value_type epsilon() noexcept
         {
-            return _repr_numeric_limits::epsilon();
+            return _rep_numeric_limits::epsilon();
         }
 
         static constexpr _value_type round_error() noexcept
         {
-            return _repr_numeric_limits::round_error();
+            return _rep_numeric_limits::round_error();
         }
 
         // TODO: verify
-        static constexpr int min_exponent = _repr_numeric_limits::min_exponent;
-        static constexpr int max_exponent = _repr_numeric_limits::max_exponent;
+        static constexpr int min_exponent = _rep_numeric_limits::min_exponent;
+        static constexpr int max_exponent = _rep_numeric_limits::max_exponent;
 
-        static constexpr int min_exponent10 = _repr_numeric_limits::min_exponent10;
-        static constexpr int max_exponent10 = _repr_numeric_limits::max_exponent10;
+        static constexpr int min_exponent10 = _rep_numeric_limits::min_exponent10;
+        static constexpr int max_exponent10 = _rep_numeric_limits::max_exponent10;
 
-        static constexpr bool has_infinity = _repr_numeric_limits::has_infinity;
-        static constexpr bool has_quiet_NaN = _repr_numeric_limits::has_quiet_NaN;
-        static constexpr bool has_signaling_NaN = _repr_numeric_limits::has_signaling_NaN;
-        static constexpr float_denorm_style has_denorm = _repr_numeric_limits::has_denorm;
-        static constexpr bool has_denorm_loss = _repr_numeric_limits::has_denorm_loss;
+        static constexpr bool has_infinity = _rep_numeric_limits::has_infinity;
+        static constexpr bool has_quiet_NaN = _rep_numeric_limits::has_quiet_NaN;
+        static constexpr bool has_signaling_NaN = _rep_numeric_limits::has_signaling_NaN;
+        static constexpr float_denorm_style has_denorm = _rep_numeric_limits::has_denorm;
+        static constexpr bool has_denorm_loss = _rep_numeric_limits::has_denorm_loss;
 
         static constexpr _value_type infinity() noexcept
         {
-            return _repr_numeric_limits::infinity();
+            return _rep_numeric_limits::infinity();
         }
 
         static constexpr _value_type quiet_NaN() noexcept
         {
-            return _repr_numeric_limits::quiet_NaN();
+            return _rep_numeric_limits::quiet_NaN();
         }
 
         static constexpr _value_type signaling_NaN() noexcept
         {
-            return _repr_numeric_limits::signaling_NaN();
+            return _rep_numeric_limits::signaling_NaN();
         }
 
         static constexpr _value_type denorm_min() noexcept
         {
-            return _repr_numeric_limits::denorm_min();
+            return _rep_numeric_limits::denorm_min();
         }
 
-        static constexpr bool is_iec559 = _repr_numeric_limits::is_iec559;
-        static constexpr bool is_bounded = _repr_numeric_limits::is_bounded;
-        static constexpr bool is_modulo = _repr_numeric_limits::is_modulo;
+        static constexpr bool is_iec559 = _rep_numeric_limits::is_iec559;
+        static constexpr bool is_bounded = _rep_numeric_limits::is_bounded;
+        static constexpr bool is_modulo = _rep_numeric_limits::is_modulo;
 
-        static constexpr bool traps = _repr_numeric_limits::traps;
-        static constexpr bool tinyness_before = _repr_numeric_limits::tinyness_before;
-        static constexpr float_round_style round_style = _repr_numeric_limits::round_style;
+        static constexpr bool traps = _rep_numeric_limits::traps;
+        static constexpr bool tinyness_before = _rep_numeric_limits::tinyness_before;
+        static constexpr float_round_style round_style = _rep_numeric_limits::round_style;
     };
 }
 

--- a/src/test/integer.h
+++ b/src/test/integer.h
@@ -50,22 +50,22 @@ namespace sg14 {
         return static_cast<common_type>(lhs).data() OP static_cast<common_type>(rhs).data(); }
 
 #define _SG14_INTEGER_BINARY_ARITHMETIC_DEFINE(OP) \
-    template <class LhsRepr, class RhsRepr, class OverflowPolicy> \
-    constexpr auto operator OP (const integer<LhsRepr, OverflowPolicy>& lhs, const integer<RhsRepr, OverflowPolicy>& rhs) \
-    -> integer<decltype(std::declval<LhsRepr>() OP std::declval<RhsRepr>()), OverflowPolicy> { \
-        using Result = integer<decltype(std::declval<LhsRepr>() OP std::declval<RhsRepr>()), OverflowPolicy>; \
+    template <class LhsRep, class RhsRep, class OverflowPolicy> \
+    constexpr auto operator OP (const integer<LhsRep, OverflowPolicy>& lhs, const integer<RhsRep, OverflowPolicy>& rhs) \
+    -> integer<decltype(std::declval<LhsRep>() OP std::declval<RhsRep>()), OverflowPolicy> { \
+        using Result = integer<decltype(std::declval<LhsRep>() OP std::declval<RhsRep>()), OverflowPolicy>; \
         return static_cast<Result>(lhs.data() OP rhs.data()); } \
     \
-    template <class Lhs, class RhsRepr, class RhsOverflowPolicy, typename std::enable_if<std::is_fundamental<Lhs>::value, int>::type dummy = 0> \
-    constexpr auto operator OP (const Lhs& lhs, const integer<RhsRepr, RhsOverflowPolicy>& rhs) \
-    -> integer<decltype(std::declval<Lhs>() OP std::declval<RhsRepr>()), RhsOverflowPolicy> { \
-        using Result = integer<decltype(std::declval<Lhs>() OP std::declval<RhsRepr>()), RhsOverflowPolicy>; \
+    template <class Lhs, class RhsRep, class RhsOverflowPolicy, typename std::enable_if<std::is_fundamental<Lhs>::value, int>::type dummy = 0> \
+    constexpr auto operator OP (const Lhs& lhs, const integer<RhsRep, RhsOverflowPolicy>& rhs) \
+    -> integer<decltype(std::declval<Lhs>() OP std::declval<RhsRep>()), RhsOverflowPolicy> { \
+        using Result = integer<decltype(std::declval<Lhs>() OP std::declval<RhsRep>()), RhsOverflowPolicy>; \
         return static_cast<Result>(lhs OP rhs.data()); } \
     \
-    template <class LhsRepr, class LhsOverflowPolicy, class Rhs, typename std::enable_if<std::is_fundamental<Rhs>::value, int>::type dummy = 0> \
-    constexpr auto operator OP (const integer<LhsRepr, LhsOverflowPolicy>& lhs, const Rhs& rhs) \
-    -> integer<decltype(std::declval<LhsRepr>() OP std::declval<Rhs>()), LhsOverflowPolicy> { \
-        using Result = integer<decltype(std::declval<LhsRepr>() OP std::declval<Rhs>()), LhsOverflowPolicy>; \
+    template <class LhsRep, class LhsOverflowPolicy, class Rhs, typename std::enable_if<std::is_fundamental<Rhs>::value, int>::type dummy = 0> \
+    constexpr auto operator OP (const integer<LhsRep, LhsOverflowPolicy>& lhs, const Rhs& rhs) \
+    -> integer<decltype(std::declval<LhsRep>() OP std::declval<Rhs>()), LhsOverflowPolicy> { \
+        using Result = integer<decltype(std::declval<LhsRep>() OP std::declval<Rhs>()), LhsOverflowPolicy>; \
         return static_cast<Result>(lhs.data() OP rhs); }
 
 #define _SG14_INTEGER_COMPOUND_ASSIGN_DEFINE(OP, BIN_OP) \
@@ -76,25 +76,25 @@ namespace sg14 {
         return *this; }
 
 #define _SG14_INTEGER_BIT_SHIFT_DEFINE(OP) \
-    template <class LhsRepr, class LhsOverflowPolicy, class RhsRepr, class RhsOverflowPolicy> \
-    constexpr auto operator OP (const integer<LhsRepr, LhsOverflowPolicy>& lhs, const integer<RhsRepr, RhsOverflowPolicy>& rhs) \
-    -> integer<LhsRepr, LhsOverflowPolicy> { \
+    template <class LhsRep, class LhsOverflowPolicy, class RhsRep, class RhsOverflowPolicy> \
+    constexpr auto operator OP (const integer<LhsRep, LhsOverflowPolicy>& lhs, const integer<RhsRep, RhsOverflowPolicy>& rhs) \
+    -> integer<LhsRep, LhsOverflowPolicy> { \
         return lhs.data() OP rhs.data(); } \
     \
-    template <class Lhs, class RhsRepr, class RhsOverflowPolicy, typename std::enable_if<std::is_fundamental<Lhs>::value, int>::type dummy = 0> \
-    constexpr auto operator OP (const Lhs& lhs, const integer<RhsRepr, RhsOverflowPolicy>& rhs) \
+    template <class Lhs, class RhsRep, class RhsOverflowPolicy, typename std::enable_if<std::is_fundamental<Lhs>::value, int>::type dummy = 0> \
+    constexpr auto operator OP (const Lhs& lhs, const integer<RhsRep, RhsOverflowPolicy>& rhs) \
     -> Lhs { \
         return lhs OP rhs.data(); } \
     \
-    template <class LhsRepr, class LhsOverflowPolicy, class Rhs, typename std::enable_if<std::is_fundamental<Rhs>::value, int>::type dummy = 0> \
-    constexpr auto operator OP (const integer<LhsRepr, LhsOverflowPolicy>& lhs, const Rhs& rhs) \
-    -> integer<LhsRepr, LhsOverflowPolicy> { \
-        return integer<LhsRepr, LhsOverflowPolicy>(lhs.data() OP rhs); }
+    template <class LhsRep, class LhsOverflowPolicy, class Rhs, typename std::enable_if<std::is_fundamental<Rhs>::value, int>::type dummy = 0> \
+    constexpr auto operator OP (const integer<LhsRep, LhsOverflowPolicy>& lhs, const Rhs& rhs) \
+    -> integer<LhsRep, LhsOverflowPolicy> { \
+        return integer<LhsRep, LhsOverflowPolicy>(lhs.data() OP rhs); }
 
     ////////////////////////////////////////////////////////////////////////////////
     // forward-declarations
 
-    template<typename Repr, typename OverflowPolicy>
+    template<typename Rep, typename OverflowPolicy>
     class integer;
 
     namespace _integer_impl {
@@ -114,8 +114,8 @@ namespace sg14 {
                 : std::false_type {
         };
 
-        template<typename Repr, typename OverflowPolicy>
-        struct is_integer_class<integer<Repr, OverflowPolicy>>
+        template<typename Rep, typename OverflowPolicy>
+        struct is_integer_class<integer<Rep, OverflowPolicy>>
                 : std::true_type {
         };
 
@@ -249,42 +249,42 @@ namespace sg14 {
         // sg14::_integer_impl::common_type
 
         // given two integer<>, produces the type that is best suited to both of them
-        template<class LhsRepr, class RhsRepr, class OverflowPolicy>
+        template<class LhsRep, class RhsRep, class OverflowPolicy>
         struct common_type<
-                integer<LhsRepr, OverflowPolicy>,
-                integer<RhsRepr, OverflowPolicy>> {
+                integer<LhsRep, OverflowPolicy>,
+                integer<RhsRep, OverflowPolicy>> {
             using type = integer<
-                    typename sg14::common_type<LhsRepr, RhsRepr>::type,
+                    typename sg14::common_type<LhsRep, RhsRep>::type,
                     OverflowPolicy>;
         };
 
         // given a integer<> and a built-in integer type,
         // generates a integer<> type that is as big as both of them (or as close as possible)
-        template<class LhsRepr, class LhsOverflowPolicy, class RhsInteger>
+        template<class LhsRep, class LhsOverflowPolicy, class RhsInteger>
         struct common_type<
-                integer<LhsRepr, LhsOverflowPolicy>,
+                integer<LhsRep, LhsOverflowPolicy>,
                 RhsInteger,
                 typename std::enable_if<
                         !_integer_impl::is_integer_class<RhsInteger>::value
                                 && std::is_integral<RhsInteger>::value
                 >::type> {
-            using type = typename sg14::integer<typename sg14::common_type<LhsRepr, RhsInteger>::type, LhsOverflowPolicy>;
+            using type = typename sg14::integer<typename sg14::common_type<LhsRep, RhsInteger>::type, LhsOverflowPolicy>;
         };
 
         // given a integer<> and a floating-point type,
         // generates a floating-point type that is as big as both of them (or as close as possible)
-        template<class LhsRepr, class LhsOverflowPolicy, class Float>
+        template<class LhsRep, class LhsOverflowPolicy, class Float>
         struct common_type<
-                integer<LhsRepr, LhsOverflowPolicy>,
+                integer<LhsRep, LhsOverflowPolicy>,
                 Float,
                 typename std::enable_if<std::is_floating_point<Float>::value>::type> {
-            using type = typename sg14::common_type<LhsRepr, Float>::type;
+            using type = typename sg14::common_type<LhsRep, Float>::type;
         };
 
         // when first type is not integer<> and second type is, reverse the order
-        template<class Lhs, class RhsRepr, class RhsOverflowPolicy>
-        struct common_type<Lhs, integer<RhsRepr, RhsOverflowPolicy>>
-                : common_type<integer<RhsRepr, RhsOverflowPolicy>, Lhs> {
+        template<class Lhs, class RhsRep, class RhsOverflowPolicy>
+        struct common_type<Lhs, integer<RhsRep, RhsOverflowPolicy>>
+                : common_type<integer<RhsRep, RhsOverflowPolicy>, Lhs> {
         };
     }
 
@@ -292,20 +292,20 @@ namespace sg14 {
     // sg14::integer<>
 
     // an integer which can be customized to react in different ways to overflow
-    template<typename Repr = int, typename OverflowPolicy = native_overflow_policy>
+    template<typename Rep = int, typename OverflowPolicy = native_overflow_policy>
     class integer {
     public:
         ////////////////////////////////////////////////////////////////////////////////
         // types
 
-        using repr_type = Repr;
+        using repr_type = Rep;
         using overflow = OverflowPolicy;
 
         ////////////////////////////////////////////////////////////////////////////////
         // functions
 
-        template<class RhsRepr, typename std::enable_if<!_integer_impl::is_integer_class<RhsRepr>::value, int>::type dummy = 0>
-        constexpr explicit integer(const RhsRepr& rhs)
+        template<class RhsRep, typename std::enable_if<!_integer_impl::is_integer_class<RhsRep>::value, int>::type dummy = 0>
+        constexpr explicit integer(const RhsRep& rhs)
                 :repr(OverflowPolicy{}.template convert<repr_type>(rhs))
         {
         }
@@ -316,10 +316,10 @@ namespace sg14 {
         {
         }
 
-        template<typename LhsRepr>
-        constexpr explicit operator LhsRepr() const
+        template<typename LhsRep>
+        constexpr explicit operator LhsRep() const
         {
-            return static_cast<LhsRepr>(repr);
+            return static_cast<LhsRep>(repr);
         }
 
         constexpr friend integer operator-(const integer& rhs)
@@ -374,97 +374,97 @@ namespace sg14 {
     ////////////////////////////////////////////////////////////////////////////////
     // integer<> partial specializations
 
-    template<typename Repr = int>
-    using native_integer = integer<Repr, native_overflow_policy>;
+    template<typename Rep = int>
+    using native_integer = integer<Rep, native_overflow_policy>;
 
-    template<typename Repr = int>
-    using throwing_integer = integer<Repr, throwing_overflow_policy>;
+    template<typename Rep = int>
+    using throwing_integer = integer<Rep, throwing_overflow_policy>;
 
-    template<typename Repr = int>
-    using saturated_integer = integer<Repr, saturated_overflow_policy>;
+    template<typename Rep = int>
+    using saturated_integer = integer<Rep, saturated_overflow_policy>;
 
     ////////////////////////////////////////////////////////////////////////////////
     // sg14::set_width<integer<>, > partial specialization
 
-    template<class Repr, class OverflowPolicy, _width_type MinNumBits>
-    struct set_width<integer<Repr, OverflowPolicy>, MinNumBits> {
-        using type = integer<set_width_t<Repr, MinNumBits>, OverflowPolicy>;
+    template<class Rep, class OverflowPolicy, _width_type MinNumBits>
+    struct set_width<integer<Rep, OverflowPolicy>, MinNumBits> {
+        using type = integer<set_width_t<Rep, MinNumBits>, OverflowPolicy>;
     };
 
     ////////////////////////////////////////////////////////////////////////////////
     // sg14::width<integer<>> partial specialization
 
-    template<class Repr, class OverflowPolicy>
-    struct width<integer<Repr, OverflowPolicy>> : width<Repr> {
+    template<class Rep, class OverflowPolicy>
+    struct width<integer<Rep, OverflowPolicy>> : width<Rep> {
     };
 
     ////////////////////////////////////////////////////////////////////////////////
     // sg14::integer-specific specializations to std-like templates
 
     // sg14::is_integral<sg14::integer<>>
-    template<typename Repr, typename OverflowPolicy>
-    struct is_integral<integer<Repr, OverflowPolicy>>
-            : std::integral_constant<bool, is_integral<Repr>::value> {
+    template<typename Rep, typename OverflowPolicy>
+    struct is_integral<integer<Rep, OverflowPolicy>>
+            : std::integral_constant<bool, is_integral<Rep>::value> {
     };
 
     // sg14::is_unsigned<sg14::integer<>>
-    template<typename Repr, typename OverflowPolicy>
-    struct is_unsigned<integer<Repr, OverflowPolicy>>
-            : std::integral_constant<bool, is_unsigned<Repr>::value> {
+    template<typename Rep, typename OverflowPolicy>
+    struct is_unsigned<integer<Rep, OverflowPolicy>>
+            : std::integral_constant<bool, is_unsigned<Rep>::value> {
     };
 
     // sg14::is_signed<sg14::integer<>>
-    template<typename Repr, typename OverflowPolicy>
-    struct is_signed<integer<Repr, OverflowPolicy>>
-            : std::integral_constant<bool, is_signed<Repr>::value> {
+    template<typename Rep, typename OverflowPolicy>
+    struct is_signed<integer<Rep, OverflowPolicy>>
+            : std::integral_constant<bool, is_signed<Rep>::value> {
     };
 
     // sg14::make_unsigned<sg14::integer<>>
-    template<typename Repr, typename OverflowPolicy>
-    struct make_unsigned<integer<Repr, OverflowPolicy>> {
-        using type = integer<typename make_unsigned<Repr>::type, OverflowPolicy>;
+    template<typename Rep, typename OverflowPolicy>
+    struct make_unsigned<integer<Rep, OverflowPolicy>> {
+        using type = integer<typename make_unsigned<Rep>::type, OverflowPolicy>;
     };
 
     // sg14::make_signed<sg14::integer<>>
-    template<typename Repr, typename OverflowPolicy>
-    struct make_signed<integer<Repr, OverflowPolicy>> {
-        using type = integer<typename make_signed<Repr>::type, OverflowPolicy>;
+    template<typename Rep, typename OverflowPolicy>
+    struct make_signed<integer<Rep, OverflowPolicy>> {
+        using type = integer<typename make_signed<Rep>::type, OverflowPolicy>;
     };
 
     // std::common_type<T, sg14::integer>
     template<
             class Lhs,
-            class RhsRepr, class RhsOverflowPolicy>
+            class RhsRep, class RhsOverflowPolicy>
     struct common_type<
             Lhs,
-            integer<RhsRepr, RhsOverflowPolicy>>
+            integer<RhsRep, RhsOverflowPolicy>>
             : _integer_impl::common_type<
                     Lhs,
-                    integer<RhsRepr, RhsOverflowPolicy>> {
+                    integer<RhsRep, RhsOverflowPolicy>> {
     };
 
     // std::common_type<sg14::integer, T>
     template<
-            class LhsRepr, class LhsOverflowPolicy,
+            class LhsRep, class LhsOverflowPolicy,
             class Rhs>
     struct common_type<
-            integer<LhsRepr, LhsOverflowPolicy>,
+            integer<LhsRep, LhsOverflowPolicy>,
             Rhs>
             : _integer_impl::common_type<
-                    integer<LhsRepr, LhsOverflowPolicy>,
+                    integer<LhsRep, LhsOverflowPolicy>,
                     Rhs> {
     };
 
     // std::common_type<sg14::integer, sg14::integer>
     template<
-            class LhsRepr, class LhsOverflowPolicy,
-            class RhsRepr, class RhsOverflowPolicy>
+            class LhsRep, class LhsOverflowPolicy,
+            class RhsRep, class RhsOverflowPolicy>
     struct common_type<
-            integer<LhsRepr, LhsOverflowPolicy>,
-            integer<RhsRepr, RhsOverflowPolicy>>
+            integer<LhsRep, LhsOverflowPolicy>,
+            integer<RhsRep, RhsOverflowPolicy>>
             : _integer_impl::common_type<
-                    integer<LhsRepr, LhsOverflowPolicy>,
-                    integer<RhsRepr, RhsOverflowPolicy>> {
+                    integer<LhsRep, LhsOverflowPolicy>,
+                    integer<RhsRep, RhsOverflowPolicy>> {
     };
 }
 
@@ -475,10 +475,10 @@ namespace std {
     // note: some members are guessed,
     // some are temporary (assuming rounding style, traps etc.)
     // and some are undefined
-    template<class Repr, class OverflowPolicy>
-    struct numeric_limits<sg14::integer<Repr, OverflowPolicy>> {
+    template<class Rep, class OverflowPolicy>
+    struct numeric_limits<sg14::integer<Rep, OverflowPolicy>> {
         // integer-specific helpers
-        using _value_type = sg14::integer<Repr, OverflowPolicy>;
+        using _value_type = sg14::integer<Rep, OverflowPolicy>;
         using _repr_type = typename _value_type::repr_type;
         using _repr_numeric_limits = numeric_limits<_repr_type>;
 

--- a/src/test/integer.h
+++ b/src/test/integer.h
@@ -1,3 +1,4 @@
+
 //          Copyright John McFarlane 2015 - 2016.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file ../LICENSE_1_0.txt or copy at
@@ -72,7 +73,7 @@ namespace sg14 {
     template <class Rhs> \
     auto operator OP (const Rhs& rhs) \
     -> integer& { \
-        repr = static_cast<repr_type>(repr BIN_OP rhs); \
+        _r = static_cast<repr_type>(_r BIN_OP rhs); \
         return *this; }
 
 #define _SG14_INTEGER_BIT_SHIFT_DEFINE(OP) \
@@ -306,25 +307,25 @@ namespace sg14 {
 
         template<class RhsRep, typename std::enable_if<!_integer_impl::is_integer_class<RhsRep>::value, int>::type dummy = 0>
         constexpr explicit integer(const RhsRep& rhs)
-                :repr(OverflowPolicy{}.template convert<repr_type>(rhs))
+                :_r(OverflowPolicy{}.template convert<repr_type>(rhs))
         {
         }
 
         template<class Rhs, typename std::enable_if<_integer_impl::is_integer_class<Rhs>::value, int>::type dummy = 0>
         constexpr explicit integer(const Rhs& rhs)
-                :repr(OverflowPolicy{}.template convert<repr_type>(rhs.data()))
+                :_r(OverflowPolicy{}.template convert<repr_type>(rhs.data()))
         {
         }
 
         template<typename LhsRep>
         constexpr explicit operator LhsRep() const
         {
-            return static_cast<LhsRep>(repr);
+            return static_cast<LhsRep>(_r);
         }
 
         constexpr friend integer operator-(const integer& rhs)
         {
-            return integer(-rhs.repr);
+            return integer(-rhs._r);
         }
 
         _SG14_INTEGER_COMPOUND_ASSIGN_DEFINE(+=, +);
@@ -337,14 +338,14 @@ namespace sg14 {
 
         constexpr repr_type const& data() const
         {
-            return repr;
+            return _r;
         }
 
     private:
         ////////////////////////////////////////////////////////////////////////////////
         // variables
 
-        repr_type repr;
+        repr_type _r;
     };
 
     _SG14_INTEGER_COMPARISON_DEFINE(==);


### PR DESCRIPTION
Replaces instances of `Repr` and `ReprType` and all variants with `Rep` or equivalent in line with naming conventions in APIs of `std::chrono`.
