### PR TITLE
Common

### DIFF
--- a/doc/p0037.md
+++ b/doc/p0037.md
@@ -206,19 +206,21 @@ promotion-like rules are applied to determine the return type:
 
 1. If both arguments are fixed-point, 
    then the result has a `Rep` which is the common type of the `Rep` of the inputs
-   and the `Exponent` value of the input with the greater integer capacity.
+   and a value of `Exponent` that avoids risk of overflow
+   but otherwise is the lower of lower of the two operands' exponents.
 2. If one of the arguments is a floating-point type, then the type of
    the result is the smallest floating-point type of equal or greater
    size than the inputs.
 3. If one of the arguments is an integral type, 
-   then the result has a `Rep` which is the common type of the input fixed-point `Rep` and the integral type 
-   and the same `Exponent` value as the input fixed-point type.
+   then it is converted to a `fixed_point<>` type with `Exponent` zero
+   such that rule 1) applies.
 
 Some examples:
-
-    fixed_point<uint8_t, -3>{8} + fixed_point<int8_t, -4>{3} == fixed_point<int, -3>{11};
-    fixed_point<uint8_t, -3>{8} + 3 == fixed_point<unsigned, -3>{11};  
-    fixed_point<uint8_t, -3>{8} + float{3} == float{11};  
+```c++11
+fixed_point<uint8_t, -3>{8} + fixed_point<int8_t, -4>{3} === fixed_point<int, -4>{11}
+fixed_point<uint8_t, -3>{8} + 3 === fixed_point<int, -3>{11}
+fixed_point<uint8_t, -3>{8} + float{3} === float{11}
+```
 
 The reasoning behind this choice is a combination of predictability
 and performance. It is explained for each rule as follows:

--- a/include/sg14/auxiliary/integer.h
+++ b/include/sg14/auxiliary/integer.h
@@ -101,9 +101,7 @@ namespace sg14 {
     namespace _integer_impl {
         template<class, class, class = void>
         struct common_type;
-    };
 
-    namespace _integer_impl {
         ////////////////////////////////////////////////////////////////////////////////
         // sg14::_integer_impl::is_integer_class - trait to identify sg14::integer<>
 

--- a/include/sg14/auxiliary/integer.h
+++ b/include/sg14/auxiliary/integer.h
@@ -429,17 +429,19 @@ namespace sg14 {
     struct make_signed<integer<Rep, OverflowPolicy>> {
         using type = integer<typename make_signed<Rep>::type, OverflowPolicy>;
     };
+}
 
+namespace std {
     // std::common_type<T, sg14::integer>
     template<
             class Lhs,
             class RhsRep, class RhsOverflowPolicy>
     struct common_type<
             Lhs,
-            integer<RhsRep, RhsOverflowPolicy>>
-            : _integer_impl::common_type<
+            sg14::integer<RhsRep, RhsOverflowPolicy>>
+            : sg14::_integer_impl::common_type<
                     Lhs,
-                    integer<RhsRep, RhsOverflowPolicy>> {
+                    sg14::integer<RhsRep, RhsOverflowPolicy>> {
     };
 
     // std::common_type<sg14::integer, T>
@@ -447,10 +449,10 @@ namespace sg14 {
             class LhsRep, class LhsOverflowPolicy,
             class Rhs>
     struct common_type<
-            integer<LhsRep, LhsOverflowPolicy>,
+            sg14::integer<LhsRep, LhsOverflowPolicy>,
             Rhs>
-            : _integer_impl::common_type<
-                    integer<LhsRep, LhsOverflowPolicy>,
+            : sg14::_integer_impl::common_type<
+                    sg14::integer<LhsRep, LhsOverflowPolicy>,
                     Rhs> {
     };
 
@@ -459,15 +461,13 @@ namespace sg14 {
             class LhsRep, class LhsOverflowPolicy,
             class RhsRep, class RhsOverflowPolicy>
     struct common_type<
-            integer<LhsRep, LhsOverflowPolicy>,
-            integer<RhsRep, RhsOverflowPolicy>>
-            : _integer_impl::common_type<
-                    integer<LhsRep, LhsOverflowPolicy>,
-                    integer<RhsRep, RhsOverflowPolicy>> {
+            sg14::integer<LhsRep, LhsOverflowPolicy>,
+            sg14::integer<RhsRep, RhsOverflowPolicy>>
+            : sg14::_integer_impl::common_type<
+                    sg14::integer<LhsRep, LhsOverflowPolicy>,
+                    sg14::integer<RhsRep, RhsOverflowPolicy>> {
     };
-}
 
-namespace std {
     ////////////////////////////////////////////////////////////////////////////////
     // std::numeric_limits specialization for integer
 

--- a/include/sg14/auxiliary/integer.h
+++ b/include/sg14/auxiliary/integer.h
@@ -7,7 +7,7 @@
 #if !defined(SG14_INTEGER_H)
 #define SG14_INTEGER_H 1
 
-#include <sg14/type_traits.h>
+#include <sg14/fixed_point.h>
 
 #include <limits>
 #include <stdexcept>
@@ -456,6 +456,30 @@ namespace std {
                     Rhs> {
     };
 
+    // std::common_type<sg14::integer, sg14::fixed_point>
+    template<
+            class LhsRep, class LhsOverflowPolicy,
+            class RhsRep, int RhsExponent>
+    struct common_type<
+            sg14::integer<LhsRep, LhsOverflowPolicy>,
+            sg14::fixed_point<RhsRep, RhsExponent>>
+            : std::common_type<
+                    sg14::fixed_point<sg14::integer<LhsRep, LhsOverflowPolicy>, 0>,
+                    sg14::fixed_point<RhsRep, RhsExponent>> {
+    };
+
+    // std::common_type<sg14::fixed_point, sg14::integer>
+    template<
+            class LhsRep, int LhsExponent,
+            class RhsRep, class RhsOverflowPolicy>
+    struct common_type<
+            sg14::fixed_point<LhsRep, LhsExponent>,
+            sg14::integer<RhsRep, RhsOverflowPolicy>>
+            : std::common_type<
+                    sg14::fixed_point<LhsRep, LhsExponent>,
+                    sg14::fixed_point<sg14::integer<RhsRep, RhsOverflowPolicy>, 0>> {
+    };
+    
     // std::common_type<sg14::integer, sg14::integer>
     template<
             class LhsRep, class LhsOverflowPolicy,

--- a/include/sg14/bits/common.h
+++ b/include/sg14/bits/common.h
@@ -36,6 +36,14 @@ namespace sg14 {
         // TODO: If this needs decay, so does common_type. Investigate. Remove decay here
         template<class ... T>
         using common_type_t = typename std::common_type<typename std::decay<T>::type ...>::type;
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // sg14::_impl::equal_value_and_type
+
+        template<class Lhs, class Rhs>
+        constexpr bool equal_value_and_type(Lhs&& lhs, Rhs&& rhs) {
+            return std::is_same<Lhs, Rhs>::value && lhs == rhs;
+        }
     }
 }
 

--- a/include/sg14/bits/common.h
+++ b/include/sg14/bits/common.h
@@ -28,6 +28,14 @@ namespace sg14 {
         {
             return (a<b) ? a : b;
         }
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // sg14::_impl::common_type_t
+
+        // pre-C++14 common_type_t
+        // TODO: If this needs decay, so does common_type. Investigate. Remove decay here
+        template<class ... T>
+        using common_type_t = typename std::common_type<typename std::decay<T>::type ...>::type;
     }
 }
 

--- a/include/sg14/bits/common.h
+++ b/include/sg14/bits/common.h
@@ -19,6 +19,15 @@ namespace sg14 {
         {
             return (a<b) ? b : a;
         }
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // sg14::_impl::max
+
+        template<class T>
+        constexpr T min(T a, T b)
+        {
+            return (a<b) ? a : b;
+        }
     }
 }
 

--- a/include/sg14/bits/fixed_point_extras.h
+++ b/include/sg14/bits/fixed_point_extras.h
@@ -23,9 +23,9 @@ namespace sg14 {
 
     template<class Rep, int Exponent, typename std::enable_if<std::is_signed<Rep>::value, int>::type Dummy = 0>
     constexpr auto abs(const fixed_point <Rep, Exponent>& x) noexcept
-    -> _fixed_point_impl::common_type_t<decltype(x), decltype(-x)>
+    -> _impl::common_type_t<decltype(x), decltype(-x)>
     {
-        using common_type = _fixed_point_impl::common_type_t<decltype(x), decltype(-x)>;
+        using common_type = _impl::common_type_t<decltype(x), decltype(-x)>;
         return (x.data()>=0)
                ? static_cast<common_type>(x)
                : static_cast<common_type>(-x);

--- a/include/sg14/fixed_point.h
+++ b/include/sg14/fixed_point.h
@@ -564,26 +564,26 @@ namespace sg14 {
             template<class Lhs, class Rhs>
             struct add : operator_base<Lhs, Rhs> {
                 using result_type = fixed_point<decltype(std::declval<typename Lhs::rep>()
-                        +std::declval<typename Rhs::rep>()), _impl::min(Lhs::exponent, Rhs::exponent)>;
+                        +std::declval<typename Rhs::rep>()), _impl::min<int>(Lhs::exponent, Rhs::exponent)>;
             };
 
             template<class Lhs, class Rhs>
             struct subtract : operator_base<Lhs, Rhs> {
                 using result_type = fixed_point<decltype(std::declval<typename Lhs::rep>()
-                        -std::declval<typename Rhs::rep>()), _impl::min(Lhs::exponent, Rhs::exponent)>;
+                        -std::declval<typename Rhs::rep>()), _impl::min<int>(Lhs::exponent, Rhs::exponent)>;
             };
 
             template<class Lhs, class Rhs>
             struct multiply : operator_base<Lhs, Rhs> {
                 using result_type = fixed_point<decltype(std::declval<typename Lhs::rep>()
-                        *std::declval<typename Rhs::rep>()), _impl::min(Lhs::exponent, Rhs::exponent)>;
+                        *std::declval<typename Rhs::rep>()), _impl::min<int>(Lhs::exponent, Rhs::exponent)>;
                 using lhs_type = widen_integer_result_t<Lhs>;
             };
 
             template<class Lhs, class Rhs>
             struct divide : operator_base<Lhs, Rhs> {
                 using result_type = fixed_point<decltype(std::declval<typename Lhs::rep>()
-                        /std::declval<typename Rhs::rep>()), _impl::min(Lhs::exponent, Rhs::exponent)>;
+                        /std::declval<typename Rhs::rep>()), _impl::min<int>(Lhs::exponent, Rhs::exponent)>;
                 using lhs_type = widen_fractional_result_t<Lhs>;
             };
         };

--- a/include/sg14/fixed_point.h
+++ b/include/sg14/fixed_point.h
@@ -46,6 +46,12 @@ namespace sg14 {
 
     namespace _fixed_point_impl {
         ////////////////////////////////////////////////////////////////////////////////
+        // sg14::_fixed_point_impl::digits
+
+        template<class T>
+        using digits = std::integral_constant<int, width<T>::value-is_signed<T>::value>;
+
+        ////////////////////////////////////////////////////////////////////////////////
         // sg14::_fixed_point_impl::float_of_same_size
 
         template<class T>
@@ -250,7 +256,7 @@ namespace sg14 {
 
         /// number of binary digits this type can represent;
         /// equivalent to [std::numeric_limits::digits](http://en.cppreference.com/w/cpp/types/numeric_limits/digits)
-        constexpr static int digits = width<Rep>::value-is_signed<Rep>::value;
+        constexpr static int digits = _fixed_point_impl::digits<Rep>::value;
 
         /// number of binary digits devoted to integer part of value;
         /// can be negative for specializations with especially small ranges

--- a/include/sg14/fixed_point.h
+++ b/include/sg14/fixed_point.h
@@ -601,7 +601,7 @@ namespace sg14 {
         template<class Lhs, class Rhs, class _Enable = void>
         struct _common_type_mixed;
 
-        // given a fixed-point and a integer type,
+        // given a fixed-point and an integer type,
         // generates a fixed-point type that is as big as both of them (or as close as possible)
         template<class LhsRep, int LhsExponent, class RhsInteger>
         struct _common_type_mixed<

--- a/src/test/fixed_point_common.h
+++ b/src/test/fixed_point_common.h
@@ -147,12 +147,16 @@ static_assert(static_cast<int>(-3.0)==-3, "incorrect assumption about default ro
 static_assert(static_cast<int>(-3.9)==-3, "incorrect assumption about default rounding");
 
 // mixed-mode operations DO lose precision because exponent is more important than significand
-static_assert(is_same<sg14::common_type<float, uint32>::type, float>::value, "incorrect assumption about promotion");
+static_assert(is_same<std::common_type<float, uint32>::type, float>::value, "incorrect assumption about promotion");
 
 // promotion doesn't always tend towards int
-static_assert(is_same<sg14::common_type<int64, uint32>::type, int64>::value, "incorrect assumption about promotion");
-static_assert(is_same<sg14::common_type<int32, uint64>::type, uint64>::value, "incorrect assumption about promotion");
-static_assert(is_same<decltype(int8(0) + int8(0)), test_int>::value, "incorrect assumption about promotion");
+static_assert(is_same<std::common_type<int64, uint32>::type, int64>::value, "incorrect assumption about promotion");
+static_assert(is_same<std::common_type<int32, uint64>::type, uint64>::value, "incorrect assumption about promotion");
+static_assert(is_same<std::common_type<int8, int8>::type, int8>::value, "incorrect assumption about promotion");
+static_assert(is_same<decltype(int8(0)+int8(0)), test_int>::value, "incorrect assumption about promotion");
+static_assert(is_same<decltype(int8(0)+int8(0)), test_int>::value, "incorrect assumption about promotion");
+static_assert(is_same<decltype(uint8(0)+int8(0)), test_int>::value, "incorrect assumption about promotion");
+static_assert(is_same<decltype(uint8(0)+uint8(0)), test_int>::value, "incorrect assumption about promotion");
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -361,8 +365,7 @@ static_assert(fixed_point<int8, -7>(1)!=1.L, "sg14::fixed_point test failed");
 static_assert(fixed_point<int8, -7>(.5)==.5f, "sg14::fixed_point test failed");
 static_assert(fixed_point<int8, -7>(.125f)==.125L, "sg14::fixed_point test failed");
 #if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
-static_assert(!(fixed_point<int16, -7>(123.125f)==123), "sg14::fixed_point test failed");
-static_assert(fixed_point<int16, -7>(123.125f)!=123, "sg14::fixed_point test failed");
+static_assert(fixed_point<int16, -7>(123.125f)==123.125f, "sg14::fixed_point test failed");
 #endif
 static_assert(fixed_point<int32, -7>(123.125f)==123.125, "sg14::fixed_point test failed");
 static_assert(fixed_point<int64, -7>(123.125l)==123.125f, "sg14::fixed_point test failed");
@@ -427,48 +430,52 @@ static_assert(
                 _impl::default_arithmetic_policy::add<
                         fixed_point<uint8, -3>,
                         fixed_point<uint8, -4>>::result_type,
-                fixed_point<decltype(std::declval<uint8>() + std::declval<uint8>()), -3>>::value,
+                fixed_point<decltype(std::declval<uint8>()+std::declval<uint8>()), -4>>::value,
         "sg14::_impl::default_arithmtic_policy test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::_impl::common_type_t
 
 // commonality never occurs when inputs are the same fixed_point type
-static_assert(is_same<_impl::common_type_t<fixed_point<int8, -3>, fixed_point<int8, -3>>, fixed_point<int8, -3>>::value,
+static_assert(
+        is_same<sg14::_impl::common_type_t<fixed_point<int8, -3>, fixed_point<int8, -3>>, fixed_point<int8, -3>>::value,
         "sg14::_impl::common_type_t test failed");
 static_assert(
-        is_same<_impl::common_type_t<fixed_point<int32, -14>, fixed_point<int32, -14>>, fixed_point<int32, -14>>::value,
+        is_same<sg14::_impl::common_type_t<fixed_point<int32, -14>, fixed_point<int32, -14>>, fixed_point<int32, -14>>::value,
         "sg14::_impl::common_type_t test failed");
 static_assert(
-        is_same<_impl::common_type_t<fixed_point<int64, -48>, fixed_point<int64, -48>>, fixed_point<int64, -48>>::value,
+        is_same<sg14::_impl::common_type_t<fixed_point<int64, -48>, fixed_point<int64, -48>>, fixed_point<int64, -48>>::value,
         "sg14::_impl::common_type_t test failed");
 
 // commonality between homogeneous fixed_point types
-static_assert(is_same<_impl::common_type_t<fixed_point<uint8, -4>, fixed_point<int8, -4>>, fixed_point<test_int, -4>>::value,
+static_assert(
+        is_same<sg14::_impl::common_type_t<fixed_point<uint8, -4>, fixed_point<int8, -4>>, fixed_point<test_int, -4>>::value,
         "sg14::_impl::common_type_t test failed");
 static_assert(
-        is_same<_impl::common_type_t<fixed_point<int16, -4>, fixed_point<int32, -14>>, fixed_point<int32, -14>>::value,
+        is_same<sg14::_impl::common_type_t<fixed_point<int16, -4>, fixed_point<int32, -14>>, fixed_point<int32, -14>>::value,
         "sg14::_impl::common_type_t test failed");
 static_assert(
-        is_same<_impl::common_type_t<fixed_point<int16, 0>, fixed_point<uint64, -60>>, fixed_point<uint64, 0>>::value,
+        is_same<sg14::_impl::common_type_t<fixed_point<int16, 0>, fixed_point<uint64, -60>>, fixed_point<uint64, -49>>::value,
         "sg14::_impl::common_type_t test failed");
 
 // commonality between arithmetic and fixed_point types
-static_assert(is_same<_impl::common_type_t<float, fixed_point<int8, -4>>, float>::value,
+static_assert(is_same<sg14::_impl::common_type_t<float, fixed_point<int8, -4>>, float>::value,
         "sg14::_impl::common_type_t test failed");
-static_assert(is_same<_impl::common_type_t<double, fixed_point<int32, -14>>, double>::value,
+static_assert(is_same<sg14::_impl::common_type_t<double, fixed_point<int32, -14>>, double>::value,
         "sg14::_impl::common_type_t test failed");
-static_assert(is_same<_impl::common_type_t<int8, fixed_point<uint64, -60>>, fixed_point<uint64, -60>>::value,
+static_assert(is_same<sg14::_impl::common_type_t<int8, fixed_point<uint64, -60>>, fixed_point<uint64, -57>>::value,
         "sg14::_impl::common_type_t test failed");
-static_assert(is_same<_impl::common_type_t<fixed_point<uint8, -4>, uint32>, fixed_point<test_unsigned, -4>>::value,
+
+static_assert(
+        is_same<sg14::_impl::common_type_t<fixed_point<uint8, -4>, uint32>, fixed_point<test_unsigned, 0>>::value,
         "sg14::_impl::common_type_t test failed");
-static_assert(is_same<_impl::common_type_t<fixed_point<int16, -4>, float>, float>::value,
+static_assert(is_same<sg14::_impl::common_type_t<fixed_point<int16, -4>, float>, float>::value,
         "sg14::_impl::common_type_t test failed");
-static_assert(is_same<_impl::common_type_t<fixed_point<int16, 0>, double>, double>::value,
+static_assert(is_same<sg14::_impl::common_type_t<fixed_point<int16, 0>, double>, double>::value,
         "sg14::_impl::common_type_t test failed");
 static_assert(is_same<
-        _impl::common_type_t<fixed_point<uint8, 10>, test_int>,
-        fixed_point<test_int, 10>>::value, "sg14::_impl::common_type_t test failed");
+        sg14::_impl::common_type_t<fixed_point<uint8, 10>, test_int>,
+        fixed_point<test_int, 0>>::value, "sg14::_impl::common_type_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::multiply
@@ -555,12 +562,12 @@ static_assert(
 #if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
 static_assert(fixed_point<uint8, 10>(10240)+2048==12288, "test failed");
 #endif
-static_assert(is_same<decltype(fixed_point<uint8, 10>(10240)+2048), fixed_point<test_signed, 10>>::value,
+static_assert(is_same<decltype(fixed_point<uint8, 10>(10240)+2048), fixed_point<test_signed, 0>>::value,
         "sg14::fixed_point addition operator test failed");
 #if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
 static_assert(2048+fixed_point<uint8, 10>(10240)==12288, "sg14::fixed_point addition operator test failed");
 #endif
-static_assert(is_same<decltype(2048+fixed_point<uint8, 10>(10240)), fixed_point<test_signed, 10>>::value,
+static_assert(is_same<decltype(2048+fixed_point<uint8, 10>(10240)), fixed_point<test_signed, 0>>::value,
         "sg14::fixed_point addition operator test failed");
 
 static_assert(765.432f+make_fixed<31, 32>(16777215.996093750)==16777981.428100586, "sg14::fixed_point addition operator test failed");
@@ -585,7 +592,7 @@ static_assert(is_same<decltype(make_fixed<2, 5, test_int>(2.125)-make_fixed<2, 5
 #if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
 static_assert(fixed_point<uint8, 10>(10240)-2048==8192, "sg14::fixed_point subtraction test failed");
 #endif
-static_assert(is_same<decltype(fixed_point<uint8, 10>(10240)-2048), fixed_point<test_signed, 10>>::value,
+static_assert(is_same<decltype(fixed_point<uint8, 10>(10240)-2048), fixed_point<test_signed, 0>>::value,
         "sg14::fixed_point subtraction test failed");
 static_assert(765.432f-make_fixed<31, 32>(16777215.996093750)==-16776450.564086914, "sg14::fixed_point subtraction test failed");
 static_assert(is_same<decltype(765.432f-make_fixed<31, 32>(16777215.996093750)), double>::value,
@@ -622,8 +629,12 @@ static_assert(is_same<decltype(make_fixed<31, 32>(16777215.996093750)*-123.654f)
 // division
 static_assert(fixed_point<int8, -1>(63) / fixed_point<int8, -1>(-4) == -15.5, "sg14::fixed_point test failed");
 
+static_assert(
+        is_same<decltype(declval<fixed_point<int8, 1>>()
+                /declval<fixed_point<int8, 1>>()), fixed_point<test_int, 1>>::value,
+        "std::fixed_point test failed");
 #if defined(TEST_NATIVE_OVERFLOW) && !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
-static_assert((fixed_point<int8, 1>(-255)/fixed_point<int8, 1>(-8))==31, "sg14::fixed_point test failed");
+static_assert((fixed_point<int8, 1>(-255)/fixed_point<int8, 1>(-8))==30, "sg14::fixed_point test failed");
 #endif
 
 #if defined(TEST_SATURATED_OVERFLOW) && !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
@@ -733,7 +744,7 @@ struct FixedPointTester {
 
     // unary common_type_t
     static_assert(is_same<
-                    _impl::common_type_t<fixed_point>,
+                    sg14::_impl::common_type_t<fixed_point>,
                     ::fixed_point<
                             typename sg14::common_type<Rep>::type,
                             Exponent>>::value,
@@ -742,22 +753,22 @@ struct FixedPointTester {
     static_assert(
             is_same<
                     fixed_point,
-                    _impl::common_type_t<fixed_point>>::value,
+                    sg14::_impl::common_type_t<fixed_point>>::value,
             "... and that rule should be to do nothing very exciting at all");
 
     // binary common_type_t
     static_assert(
             is_same<
                     fixed_point,
-                    _impl::common_type_t<fixed_point, fixed_point>>::value,
+                    sg14::_impl::common_type_t<fixed_point, fixed_point>>::value,
             "a fixed point specialization follows the same implicit promotion rules as its Rep");
 
     // for convenience, fixed_point API assumes binary and unary homogeneous common_types are the same
     static_assert(
             is_same<
-                    _impl::common_type_t<fixed_point>,
-                    _impl::common_type_t<fixed_point, fixed_point>>::value,
-            "bad assumption about binary _impl::common_type_t");
+                    sg14::_impl::common_type_t<fixed_point>,
+                    sg14::_impl::common_type_t<fixed_point, fixed_point>>::value,
+            "bad assumption about binary sg14::_impl::common_type_t");
 
     // test promotion rules for arithmetic
     static_assert(

--- a/src/test/integer.cpp
+++ b/src/test/integer.cpp
@@ -22,20 +22,20 @@ using std::numeric_limits;
 // std::common_type with sg14::integer parameter
 
 static_assert(is_same<
-        typename sg14::common_type<int32_t, saturated_integer<int16_t>>::type,
+        typename std::common_type<int32_t, saturated_integer<int16_t>>::type,
         saturated_integer<int32_t>>::value, "sg14::_integer_impl::common_type test failure");
 
 static_assert(is_same<
-        sg14::common_type<saturated_integer<int8_t>, saturated_integer<int8_t>>::type,
+        std::common_type<saturated_integer<int8_t>, saturated_integer<int8_t>>::type,
         saturated_integer<int8_t>>::value, "sg14::_integer_impl::common_type test failure");
 
 static_assert(is_same<
-        sg14::common_type<saturated_integer<uint32_t>, float>::type,
+        std::common_type<saturated_integer<uint32_t>, float>::type,
         float>::value, "incorrect assumption about promotion");
 
 static_assert(is_same<
-        sg14::common_type<saturated_integer<uint32_t>, saturated_integer<int16_t>>::type,
-        saturated_integer<uint32_t >>::value, "sg14::common_type test failed");
+        std::common_type<saturated_integer<uint32_t>, saturated_integer<int16_t>>::type,
+        saturated_integer<uint32_t >>::value, "std::common_type test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::_integer_impl::is_integer_class

--- a/src/test/proposal.cpp
+++ b/src/test/proposal.cpp
@@ -36,20 +36,10 @@ TEST(proposal, make_fixed)
 static_assert(make_ufixed<4, 4>{.006}==make_ufixed<4, 4>{0}, "Incorrect information in proposal section, Conversion");
 
 // Operator Overloads
-static_assert(fixed_point<uint8_t, -3>{8} + fixed_point<uint8_t, -4>{3} == fixed_point<unsigned, -3>{11},
-        "Incorrect information in proposal section, Operator Overloads");
-static_assert(is_same<decltype(fixed_point<uint8_t, -3>{8} + fixed_point<int8_t, -4>{3}), decltype(fixed_point<int, -3>{11})>::value,
-        "Incorrect information in proposal section, Operator Overloads");
 
-static_assert(make_ufixed<5, 3>{8}+3==fixed_point<signed, -3>{11},
-        "Incorrect information in proposal section, Operator Overloads");
-static_assert(is_same<decltype(make_ufixed<5, 3>{8}+3), decltype(fixed_point<signed, -3>{11})>::value,
-        "Incorrect information in proposal section, Operator Overloads");
-
-static_assert(make_ufixed<5, 3>{8}+float{3}==float{11},
-        "Incorrect information in proposal section, Operator Overloads");
-static_assert(is_same<decltype(make_ufixed<5, 3>{8}+float{3}), decltype(float{11})>::value,
-        "Incorrect information in proposal section, Operator Overloads");
+static_assert(sg14::_impl::equal_value_and_type(fixed_point<uint8_t, -3>{8} + fixed_point<int8_t, -4>{3}, fixed_point<int, -4>{11}), "Incorrect information in P0037 section, Operator Overloads");
+static_assert(sg14::_impl::equal_value_and_type(fixed_point<uint8_t, -3>{8} + 3, fixed_point<int, -3>{11}), "Incorrect information in P0037 section, Operator Overloads");
+static_assert(sg14::_impl::equal_value_and_type(fixed_point<uint8_t, -3>{8} + float{3}, float{11}), "Incorrect information in P0037 section, Operator Overloads");
 
 // Overflow
 TEST(proposal, overflow) {


### PR DESCRIPTION
std::common_type for `integer<>` and `fixed_point<>` types
