### PR TITLE
Int128 fixes

### DIFF
--- a/include/sg14/auxiliary/multiprecision.h
+++ b/include/sg14/auxiliary/multiprecision.h
@@ -10,9 +10,9 @@
 #if !defined(SG14_MULTIPRECISION_H)
 #define SG14_MULTIPRECISION_H 1
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <sg14/auxiliary/elastic.h>
+
+#include <boost/multiprecision/cpp_int.hpp>
 
 namespace sg14 {
     namespace _bmp {

--- a/include/sg14/bits/int128.h
+++ b/include/sg14/bits/int128.h
@@ -103,6 +103,7 @@ namespace sg14 {
 }
 
 namespace std {
+#if defined(SG14_INT128_ENABLED)
     template<>
     struct numeric_limits<SG14_INT128> : numeric_limits<long long> {
         static const int digits = CHAR_BIT*sizeof(SG14_INT128)-1;
@@ -156,6 +157,7 @@ namespace std {
             return min();
         }
     };
+#endif
 }
 
 #endif // SG14_INT128_H

--- a/include/sg14/bits/int128.h
+++ b/include/sg14/bits/int128.h
@@ -102,4 +102,60 @@ namespace sg14 {
 #endif
 }
 
+namespace std {
+    template<>
+    struct numeric_limits<SG14_INT128> : numeric_limits<long long> {
+        static const int digits = CHAR_BIT*sizeof(SG14_INT128)-1;
+        static const int digits10 = 38;
+
+        struct _s {
+            constexpr _s(uint64_t upper, uint64_t lower) : value(lower + (SG14_INT128{upper} << 64)) {}
+            constexpr operator SG14_INT128() const { return value; }
+            SG14_INT128 value;
+        };
+
+        static constexpr SG14_INT128 min()
+        {
+            return _s(0x8000000000000000, 0x0000000000000000);
+        }
+
+        static constexpr SG14_INT128 max()
+        {
+            return _s(0x7fffffffffffffff, 0xffffffffffffffff);
+        }
+
+        static constexpr SG14_INT128 lowest()
+        {
+            return min();
+        }
+    };
+
+    template<>
+    struct numeric_limits<SG14_UINT128> : numeric_limits<unsigned long long> {
+        static const int digits = CHAR_BIT*sizeof(SG14_INT128);
+        static const int digits10 = 38;
+
+        struct _s {
+            constexpr _s(uint64_t upper, uint64_t lower) : value(lower + (SG14_UINT128{upper} << 64)) {}
+            constexpr operator SG14_INT128() const { return value; }
+            SG14_UINT128 value;
+        };
+
+        static constexpr SG14_INT128 min()
+        {
+            return 0;
+        }
+
+        static constexpr SG14_INT128 max()
+        {
+            return _s(0xffffffffffffffff, 0xffffffffffffffff);
+        }
+
+        static constexpr SG14_INT128 lowest()
+        {
+            return min();
+        }
+    };
+}
+
 #endif // SG14_INT128_H

--- a/include/sg14/bits/int128.h
+++ b/include/sg14/bits/int128.h
@@ -7,9 +7,9 @@
 #ifndef SG14_INT128_H
 #define SG14_INT128_H
 
-#include "config.h"
+#include <limits>
 
-#include "../type_traits.h"
+#include "config.h"
 
 // This file contains tweaks to standard traits that integers more conducive to generic programming.
 

--- a/include/sg14/bits/int128.h
+++ b/include/sg14/bits/int128.h
@@ -79,7 +79,7 @@ namespace sg14 {
 
     template<>
     struct make_unsigned<SG14_UINT128> {
-        using type = SG14_INT128;
+        using type = SG14_UINT128;
     };
 
     // sg14::resize

--- a/include/sg14/type_traits.h
+++ b/include/sg14/type_traits.h
@@ -286,4 +286,6 @@ namespace sg14 {
     };
 }
 
+#include "bits/int128.h"
+
 #endif	// SG14_TYPE_TRAITS_H

--- a/src/test/type_traits.cpp
+++ b/src/test/type_traits.cpp
@@ -143,7 +143,13 @@ struct test_built_in_width {
 
 template<typename T>
 struct test_built_in
-        : test_built_in_width<T>, test_built_in_set_width<T, 64> {
+        : test_built_in_width<T>,
+#if defined(SG14_INT128_ENABLED)
+          test_built_in_set_width<T, 128>
+#else
+          test_built_in_set_width<T, 64>
+#endif
+{
 };
 
 template
@@ -168,3 +174,9 @@ template
 struct test_built_in<unsigned long long>;
 template
 struct test_built_in<signed long long>;
+#if defined(SG14_INT128_ENABLED)
+template
+struct test_built_in<SG14_UINT128>;
+template
+struct test_built_in<SG14_INT128>;
+#endif

--- a/src/test/type_traits.cpp
+++ b/src/test/type_traits.cpp
@@ -5,7 +5,6 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <sg14/type_traits.h>
-#include <sg14/bits/int128.h>
 
 using sg14::_type_traits_impl::first_fit;
 using std::is_same;

--- a/src/test/type_traits.cpp
+++ b/src/test/type_traits.cpp
@@ -8,10 +8,10 @@
 
 using sg14::_type_traits_impl::first_fit;
 using std::is_same;
-using std::is_signed;
-using std::is_unsigned;
-using std::make_signed;
-using std::make_unsigned;
+using sg14::is_signed;
+using sg14::is_unsigned;
+using sg14::make_signed;
+using sg14::make_unsigned;
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::width

--- a/src/test/type_traits.cpp
+++ b/src/test/type_traits.cpp
@@ -4,6 +4,8 @@
 //  (See accompanying file ../../LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
+#include <limits>
+
 #include <sg14/type_traits.h>
 
 using sg14::_type_traits_impl::first_fit;
@@ -62,6 +64,13 @@ static_assert(
         std::is_same<typename first_fit<16, std::tuple<std::int8_t, std::int16_t, std::int32_t>>::type, std::int16_t>::value, "");
 static_assert(
         std::is_same<typename first_fit<16, std::tuple<std::int32_t, std::int16_t, std::int8_t>>::type, std::int32_t>::value, "");
+
+////////////////////////////////////////////////////////////////////////////////
+// some random sg14::set_width
+
+#if defined(SG14_INT128_ENABLED)
+static_assert(is_same<sg14::set_width<unsigned long, 78>::type, SG14_UINT128>::value, "sg14::set_width_t test failed");
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::set_width_t
@@ -125,9 +134,13 @@ struct test_built_in_set_width : test_built_in_set_width<T, NumBits-1> {
             "result of set_width must be at least the desired width in bits");
 
     static_assert(is_signed<T>::value==is_signed<result_type>::value,
-            "incorrect signage in result of set_width_t");
+            "incorrect signage in result of set_width_t (according to is_signed)");
     static_assert(is_unsigned<T>::value==is_unsigned<result_type>::value,
-            "incorrect signage in result of set_width_t");
+            "incorrect signage in result of set_width_t (according to is_unsigned)");
+
+    static_assert(std::numeric_limits<result_type>::is_specialized, "numeric_limits<result_type> is not specialized");
+    static_assert(std::numeric_limits<T>::is_signed==std::numeric_limits<result_type>::is_signed,
+            "incorrect signage in result of set_width_t (according to numeric_limits)");
 
     static_assert(is_same<typename make_signed<result_type>::type, set_width_t<typename make_signed<T>::type, NumBits>>::value,
             "incorrect signage in result of set_width_t");
@@ -150,6 +163,7 @@ struct test_built_in
           test_built_in_set_width<T, 64>
 #endif
 {
+    static_assert(std::numeric_limits<T>::is_specialized, "numeric_limits<T> is not specialized");
 };
 
 template

--- a/src/test/utils.cpp
+++ b/src/test/utils.cpp
@@ -4,7 +4,7 @@
 //  (See accompanying file ../../LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <sg14/bits/int128.h>
+#include <sg14/type_traits.h>
 #include <sg14/fixed_point.h>
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
fixes bug with sg14::make_unsigned<uint128>
specializes numeric_limits for 128-bit integers
