### PR TITLE
Godbolt

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ a header-only C++11 API for approximating real numbers using binary fixed-point 
 It forms the reference implementation of a standard library proposal presented in paper, [P0037](doc/p0037.md)
 and is developed as part of study groups, [SG14](https://groups.google.com/a/isocpp.org/forum/#!forum/sg14) and SG6.
 
-## Installation
+## Download
 
 The library is [hosted](https://github.com/johnmcfarlane/fixed_point) on GitHub:
 

--- a/include/sg14/auxiliary/elastic.h
+++ b/include/sg14/auxiliary/elastic.h
@@ -10,8 +10,10 @@
 #if !defined(SG14_ELASTIC_H)
 #define SG14_ELASTIC_H 1
 
+#if ! defined(SG14_GODBOLT_ORG)
 #include "elastic_integer.h"
 #include <sg14/fixed_point>
+#endif
 
 /// study group 14 of the C++ working group
 namespace sg14 {

--- a/include/sg14/auxiliary/elastic_integer.h
+++ b/include/sg14/auxiliary/elastic_integer.h
@@ -10,9 +10,11 @@
 #if !defined(SG14_ELASTIC_INTEGER_H)
 #define SG14_ELASTIC_INTEGER_H 1
 
+#if ! defined(SG14_GODBOLT_ORG)
 #include <sg14/bits/common.h>
 #include <sg14/cstdint>
 #include <sg14/limits>
+#endif
 
 /// study group 14 of the C++ working group
 namespace sg14 {

--- a/include/sg14/auxiliary/integer.h
+++ b/include/sg14/auxiliary/integer.h
@@ -7,14 +7,14 @@
 #if !defined(SG14_INTEGER_H)
 #define SG14_INTEGER_H 1
 
+#if ! defined(SG14_GODBOLT_ORG)
 #include <sg14/fixed_point>
+#endif
 
 #include <stdexcept>
 
 #if defined(SG14_EXCEPTIONS_ENABLED)
-
 #include <stdexcept>
-
 #endif
 
 /// study group 14 of the C++ working group

--- a/include/sg14/bits/common.h
+++ b/include/sg14/bits/common.h
@@ -9,8 +9,10 @@
 #if !defined(SG14_COMMON_H)
 #define SG14_COMMON_H 1
 
+#if ! defined(SG14_GODBOLT_ORG)
 #include <sg14/type_traits>
 #include <sg14/limits>
+#endif
 
 namespace sg14 {
     namespace _impl {

--- a/include/sg14/bits/fixed_point_arithmetic.h
+++ b/include/sg14/bits/fixed_point_arithmetic.h
@@ -10,9 +10,11 @@
 #if !defined(SG14_FIXED_POINT_ARITHMETIC_H)
 #define SG14_FIXED_POINT_ARITHMETIC_H 1
 
+#if ! defined(SG14_GODBOLT_ORG)
 #include "common.h"
 
 #include "fixed_point_type.h"
+#endif
 
 /// study group 14 of the C++ working group
 namespace sg14 {

--- a/include/sg14/bits/fixed_point_common_type.h
+++ b/include/sg14/bits/fixed_point_common_type.h
@@ -10,7 +10,9 @@
 #if !defined(SG14_FIXED_POINT_COMMON_TYPE_H)
 #define SG14_FIXED_POINT_COMMON_TYPE_H 1
 
+#if ! defined(SG14_GODBOLT_ORG)
 #include "fixed_point_type.h"
+#endif
 
 /// study group 14 of the C++ working group
 namespace sg14 {

--- a/include/sg14/bits/fixed_point_extras.h
+++ b/include/sg14/bits/fixed_point_extras.h
@@ -12,7 +12,9 @@
 #if !defined(SG14_FIXED_POINT_EXTRAS_H)
 #define SG14_FIXED_POINT_EXTRAS_H 1
 
+#if ! defined(SG14_GODBOLT_ORG)
 #include "fixed_point_type.h"
+#endif
 
 #include <cmath>
 #include <istream>

--- a/include/sg14/bits/fixed_point_make.h
+++ b/include/sg14/bits/fixed_point_make.h
@@ -10,10 +10,12 @@
 #if !defined(SG14_MAKE_FIXED_H)
 #define SG14_MAKE_FIXED_H 1
 
+#if ! defined(SG14_GODBOLT_ORG)
 #include "fixed_point_type.h"
 
 #include <sg14/cstdint>
 #include <sg14/type_traits>
+#endif
 
 /// study group 14 of the C++ working group
 namespace sg14 {

--- a/include/sg14/bits/fixed_point_math.h
+++ b/include/sg14/bits/fixed_point_math.h
@@ -10,8 +10,9 @@
 #ifndef FIXED_POINT_MATH_H_
 #define FIXED_POINT_MATH_H_
 
+#if ! defined(SG14_GODBOLT_ORG)
 #include <sg14/fixed_point>
-#include <type_traits>
+#endif
 
 /// study group 14 of the C++ working group
 namespace sg14 {

--- a/include/sg14/bits/fixed_point_named.h
+++ b/include/sg14/bits/fixed_point_named.h
@@ -10,9 +10,11 @@
 #if !defined(SG14_FIXED_POINT_NAMED_H)
 #define SG14_FIXED_POINT_NAMED_H 1
 
+#if ! defined(SG14_GODBOLT_ORG)
 #include "common.h"
 
 #include "fixed_point_arithmetic.h"
+#endif
 
 /// study group 14 of the C++ working group
 namespace sg14 {

--- a/include/sg14/bits/fixed_point_operators.h
+++ b/include/sg14/bits/fixed_point_operators.h
@@ -10,7 +10,9 @@
 #if !defined(SG14_FIXED_POINT_OPERATORS_H)
 #define SG14_FIXED_POINT_OPERATORS_H 1
 
+#if ! defined(SG14_GODBOLT_ORG)
 #include "fixed_point_arithmetic.h"
+#endif
 
 /// study group 14 of the C++ working group
 namespace sg14 {

--- a/include/sg14/bits/fixed_point_type.h
+++ b/include/sg14/bits/fixed_point_type.h
@@ -10,8 +10,10 @@
 #if !defined(SG14_FIXED_POINT_DEF_H)
 #define SG14_FIXED_POINT_DEF_H 1
 
+#if ! defined(SG14_GODBOLT_ORG)
 #include <sg14/cstdint>
 #include <sg14/limits>
+#endif
 
 /// study group 14 of the C++ working group
 namespace sg14 {

--- a/include/sg14/cstdint
+++ b/include/sg14/cstdint
@@ -10,7 +10,9 @@
 #if !defined(SG14_CSTDINT_H)
 #define SG14_CSTDINT_H 1
 
+#if ! defined(SG14_GODBOLT_ORG)
 #include "bits/config.h"
+#endif
 
 #include <climits>
 #include <cstdint>

--- a/include/sg14/limits
+++ b/include/sg14/limits
@@ -10,7 +10,9 @@
 #if !defined(SG14_LIMITS_H)
 #define SG14_LIMITS_H 1
 
+#if ! defined(SG14_GODBOLT_ORG)
 #include "bits/config.h"
+#endif
 
 #include <climits>
 #include <cstdint>


### PR DESCRIPTION
Allows `sg14::fixed_point`, `sg14::elastic` etc. to be used on [godbolt.org](http://godbolt.org/) after prefixing with:
```c++
#define SG14_develop_ORG
#include <https://raw.githubusercontent.com/johnmcfarlane/fixed_point/develop/include/sg14/bits/config.h>
#include <https://raw.githubusercontent.com/johnmcfarlane/fixed_point/develop/include/sg14/bits/config.h>
#include <https://raw.githubusercontent.com/johnmcfarlane/fixed_point/develop/include/sg14/cstdint>
#include <https://raw.githubusercontent.com/johnmcfarlane/fixed_point/develop/include/sg14/limits>
#include <https://raw.githubusercontent.com/johnmcfarlane/fixed_point/develop/include/sg14/type_traits>
#include <https://raw.githubusercontent.com/johnmcfarlane/fixed_point/develop/include/sg14/bits/common.h>
#include <https://raw.githubusercontent.com/johnmcfarlane/fixed_point/develop/include/sg14/bits/fixed_point_type.h>
#include <https://raw.githubusercontent.com/johnmcfarlane/fixed_point/develop/include/sg14/bits/fixed_point_arithmetic.h>
#include <https://raw.githubusercontent.com/johnmcfarlane/fixed_point/develop/include/sg14/bits/fixed_point_make.h>
#include <https://raw.githubusercontent.com/johnmcfarlane/fixed_point/develop/include/sg14/bits/fixed_point_named.h>
#include <https://raw.githubusercontent.com/johnmcfarlane/fixed_point/develop/include/sg14/bits/fixed_point_common_type.h>
#include <https://raw.githubusercontent.com/johnmcfarlane/fixed_point/develop/include/sg14/bits/fixed_point_operators.h>
#include <https://raw.githubusercontent.com/johnmcfarlane/fixed_point/develop/include/sg14/bits/fixed_point_extras.h>
#include <https://raw.githubusercontent.com/johnmcfarlane/fixed_point/develop/include/sg14/auxiliary/elastic_integer.h>
#include <https://raw.githubusercontent.com/johnmcfarlane/fixed_point/develop/include/sg14/auxiliary/elastic.h>
```