### PR TITLE
deduce return type of fixed_point comparison operators

### DIFF
--- a/include/sg14/bits/fixed_point_operators.h
+++ b/include/sg14/bits/fixed_point_operators.h
@@ -21,49 +21,55 @@ namespace sg14 {
     // (fixed_point @ fixed_point) comparison operators
 
     template<class Rep, int Exponent>
-    constexpr bool operator==(
+    constexpr auto operator==(
             const fixed_point<Rep, Exponent>& lhs,
             const fixed_point<Rep, Exponent>& rhs)
+    -> decltype(lhs.data()==rhs.data())
     {
         return lhs.data()==rhs.data();
     }
 
     template<class Rep, int Exponent>
-    constexpr bool operator!=(
+    constexpr auto operator!=(
             const fixed_point<Rep, Exponent>& lhs,
             const fixed_point<Rep, Exponent>& rhs)
+    -> decltype(lhs.data()!=rhs.data())
     {
         return lhs.data()!=rhs.data();
     }
 
     template<class Rep, int Exponent>
-    constexpr bool operator<(
+    constexpr auto operator<(
             const fixed_point<Rep, Exponent>& lhs,
             const fixed_point<Rep, Exponent>& rhs)
+    -> decltype(lhs.data()<rhs.data())
     {
         return lhs.data()<rhs.data();
     }
 
     template<class Rep, int Exponent>
-    constexpr bool operator>(
+    constexpr auto operator>(
             const fixed_point<Rep, Exponent>& lhs,
             const fixed_point<Rep, Exponent>& rhs)
+    -> decltype(lhs.data()>rhs.data())
     {
         return lhs.data()>rhs.data();
     }
 
     template<class Rep, int Exponent>
-    constexpr bool operator>=(
+    constexpr auto operator>=(
             const fixed_point<Rep, Exponent>& lhs,
             const fixed_point<Rep, Exponent>& rhs)
+    -> decltype(lhs.data()>=rhs.data())
     {
         return lhs.data()>=rhs.data();
     }
 
     template<class Rep, int Exponent>
-    constexpr bool operator<=(
+    constexpr auto operator<=(
             const fixed_point<Rep, Exponent>& lhs,
             const fixed_point<Rep, Exponent>& rhs)
+    -> decltype(lhs.data()<=rhs.data())
     {
         return lhs.data()<=rhs.data();
     }


### PR DESCRIPTION
- instead of assuming the result is `bool`