### PR TITLE
Number base

### DIFF
--- a/include/sg14/auxiliary/elastic_integer.h
+++ b/include/sg14/auxiliary/elastic_integer.h
@@ -455,7 +455,8 @@ namespace std {
     // some are temporary (assuming rounding style, traps etc.)
     // and some are undefined
     template<int Digits, class Narrowest>
-    struct numeric_limits<sg14::elastic_integer<Digits, Narrowest>> : numeric_limits<Narrowest> {
+    struct numeric_limits<sg14::elastic_integer<Digits, Narrowest>>
+            : numeric_limits<sg14::_elastic_integer_impl::base<Digits, Narrowest>> {
         // elastic integer-specific helpers
         using _narrowest_numeric_limits = numeric_limits<Narrowest>;
         using _value_type = sg14::elastic_integer<Digits, Narrowest>;

--- a/include/sg14/auxiliary/elastic_integer.h
+++ b/include/sg14/auxiliary/elastic_integer.h
@@ -118,8 +118,10 @@ namespace sg14 {
         /// constructor taking an integral constant
         template<typename Integral, Integral Value, int Exponent>
         constexpr elastic_integer(const_integer<Integral, Value, Digits, Exponent>)
-                : _base(Value)
+                : _base(static_cast<rep>(Value))
         {
+            static_assert(Value <= std::numeric_limits<rep>::max(), "initialization by out-of-range value");
+            static_assert(Value >= std::numeric_limits<rep>::lowest(), "initialization by out-of-range value");
         }
 
         /// copy assignment operator taking a floating-point type

--- a/include/sg14/auxiliary/precise_integer.h
+++ b/include/sg14/auxiliary/precise_integer.h
@@ -1,0 +1,84 @@
+
+//          Copyright John McFarlane 2015 - 2017.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(SG14_PRECISE_INTEGER_H)
+#define SG14_PRECISE_INTEGER_H 1
+
+#if !defined(SG14_GODBOLT_ORG)
+
+#include <sg14/bits/number_base.h>
+
+#endif
+
+#include <cstdint>
+#include <limits>
+
+namespace sg14 {
+
+    template<class Rep>
+    struct closest_rounding_policy {
+        template<class T>
+        static constexpr Rep convert(const T& from)
+        {
+            return static_cast<Rep>(std::intmax_t(from+((from>=0) ? .5 : -.5)));
+        }
+    };
+
+    template<class Rep = int, class RoundingPolicy = closest_rounding_policy<Rep>>
+    class precise_integer : public _impl::number_base<precise_integer<Rep, RoundingPolicy>, Rep> {
+        using super = _impl::number_base<precise_integer<Rep, RoundingPolicy>, Rep>;
+    public:
+        using rounding = RoundingPolicy;
+
+        constexpr precise_integer() = default;
+
+        template<class T, typename std::enable_if<std::numeric_limits<T>::is_integer, int>::type Dummy = 0>
+        constexpr precise_integer(const T& v)
+                : super(v) { }
+
+        template<class T, typename std::enable_if<!std::numeric_limits<T>::is_integer, int>::type Dummy = 0>
+        constexpr precise_integer(const T& v)
+                : super(rounding::convert(v)) { }
+    };
+
+    namespace _precise_integer_impl {
+        ////////////////////////////////////////////////////////////////////////////////
+        // comparison operators
+
+        template<class T>
+        struct is_precise_integer : std::false_type {
+        };
+
+        template<class Rep, class RoundingPolicy>
+        struct is_precise_integer<precise_integer<Rep, RoundingPolicy>> : std::true_type {
+        };
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // comparison operators
+
+    template<
+            class Lhs,
+            class RhsRep, class RhsRoundingPolicy,
+            typename std::enable_if<!_precise_integer_impl::is_precise_integer<Lhs>::value, int>::type = 0>
+    constexpr auto operator==(const Lhs& lhs, const precise_integer<RhsRep, RhsRoundingPolicy>& rhs)
+    -> decltype(lhs==to_rep(rhs))
+    {
+        return lhs==to_rep(rhs);
+    };
+
+    template<
+            class LhsRep, class LhsRoundingPolicy,
+            class Rhs,
+            typename std::enable_if<!_precise_integer_impl::is_precise_integer<Rhs>::value, int>::type = 0>
+    constexpr auto operator==(const precise_integer<LhsRep, LhsRoundingPolicy>& lhs, const Rhs& rhs)
+    -> decltype(to_rep(lhs)==rhs)
+    {
+        return to_rep(lhs)==rhs;
+    };
+}
+
+#endif

--- a/include/sg14/bits/fixed_point_extras.h
+++ b/include/sg14/bits/fixed_point_extras.h
@@ -225,7 +225,8 @@ namespace std {
     // some are temporary (assuming rounding style, traps etc.)
     // and some are undefined
     template<class Rep, int Exponent>
-    struct numeric_limits<sg14::fixed_point<Rep, Exponent>> : public std::numeric_limits<Rep> {
+    struct numeric_limits<sg14::fixed_point<Rep, Exponent>>
+            : std::numeric_limits<sg14::_impl::number_base<sg14::fixed_point<Rep, Exponent>, Rep>> {
         // fixed-point-specific helpers
         using _value_type = sg14::fixed_point<Rep, Exponent>;
         using _rep = typename _value_type::rep;
@@ -235,7 +236,7 @@ namespace std {
 
         static constexpr _value_type min() noexcept
         {
-            return _value_type::from_data(sg14::_impl::min(_rep{1}, _rep_numeric_limits::max()));
+            return _value_type::from_data(_rep{1});
         }
 
         static constexpr _value_type max() noexcept
@@ -252,32 +253,32 @@ namespace std {
 
         static constexpr _value_type epsilon() noexcept
         {
-            return _value_type::from_data(1);
+            return _value_type::from_data(_rep{1});
         }
 
         static constexpr _value_type round_error() noexcept
         {
-            return static_cast<_value_type>(0);
+            return static_cast<_value_type>(.5);
         }
 
         static constexpr _value_type infinity() noexcept
         {
-            return static_cast<_value_type>(0);
+            return _value_type::from_data(_rep{0});
         }
 
         static constexpr _value_type quiet_NaN() noexcept
         {
-            return static_cast<_value_type>(0);
+            return _value_type::from_data(_rep{0});
         }
 
         static constexpr _value_type signaling_NaN() noexcept
         {
-            return static_cast<_value_type>(0);
+            return _value_type::from_data(_rep{0});
         }
 
         static constexpr _value_type denorm_min() noexcept
         {
-            return static_cast<_value_type>(0);
+            return _value_type::from_data(_rep{1});
         }
     };
 }

--- a/include/sg14/bits/fixed_point_operators.h
+++ b/include/sg14/bits/fixed_point_operators.h
@@ -18,63 +18,6 @@
 namespace sg14 {
 
     ////////////////////////////////////////////////////////////////////////////////
-    // (fixed_point @ fixed_point) comparison operators
-
-    template<class Rep, int Exponent>
-    constexpr auto operator==(
-            const fixed_point<Rep, Exponent>& lhs,
-            const fixed_point<Rep, Exponent>& rhs)
-    -> decltype(lhs.data()==rhs.data())
-    {
-        return lhs.data()==rhs.data();
-    }
-
-    template<class Rep, int Exponent>
-    constexpr auto operator!=(
-            const fixed_point<Rep, Exponent>& lhs,
-            const fixed_point<Rep, Exponent>& rhs)
-    -> decltype(lhs.data()!=rhs.data())
-    {
-        return lhs.data()!=rhs.data();
-    }
-
-    template<class Rep, int Exponent>
-    constexpr auto operator<(
-            const fixed_point<Rep, Exponent>& lhs,
-            const fixed_point<Rep, Exponent>& rhs)
-    -> decltype(lhs.data()<rhs.data())
-    {
-        return lhs.data()<rhs.data();
-    }
-
-    template<class Rep, int Exponent>
-    constexpr auto operator>(
-            const fixed_point<Rep, Exponent>& lhs,
-            const fixed_point<Rep, Exponent>& rhs)
-    -> decltype(lhs.data()>rhs.data())
-    {
-        return lhs.data()>rhs.data();
-    }
-
-    template<class Rep, int Exponent>
-    constexpr auto operator>=(
-            const fixed_point<Rep, Exponent>& lhs,
-            const fixed_point<Rep, Exponent>& rhs)
-    -> decltype(lhs.data()>=rhs.data())
-    {
-        return lhs.data()>=rhs.data();
-    }
-
-    template<class Rep, int Exponent>
-    constexpr auto operator<=(
-            const fixed_point<Rep, Exponent>& lhs,
-            const fixed_point<Rep, Exponent>& rhs)
-    -> decltype(lhs.data()<=rhs.data())
-    {
-        return lhs.data()<=rhs.data();
-    }
-
-    ////////////////////////////////////////////////////////////////////////////////
     // (fixed_point @ fixed_point) arithmetic operators
 
     // negate
@@ -145,10 +88,17 @@ namespace sg14 {
     //
     // compare two objects of different fixed_point specializations
 
+    namespace _fixed_point_operators_impl {
+        template<typename Lhs, typename Rhs>
+        constexpr bool is_heterogeneous() {
+            return (!std::is_same<Lhs, Rhs>::value) &&
+                   (_impl::is_fixed_point<Lhs>::value || _impl::is_fixed_point<Rhs>::value);
+        }
+    }
+
     template<class Lhs, class Rhs>
     constexpr auto operator==(const Lhs& lhs, const Rhs& rhs)
-    -> typename std::enable_if<
-            _impl::is_fixed_point<Lhs>::value || _impl::is_fixed_point<Rhs>::value, bool>::type
+    -> typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>(), bool>::type
     {
         using common_type = _impl::common_type_t<Lhs, Rhs>;
         return static_cast<common_type>(lhs)==static_cast<common_type>(rhs);
@@ -156,8 +106,7 @@ namespace sg14 {
 
     template<class Lhs, class Rhs>
     constexpr auto operator!=(const Lhs& lhs, const Rhs& rhs)
-    -> typename std::enable_if<
-            _impl::is_fixed_point<Lhs>::value || _impl::is_fixed_point<Rhs>::value, bool>::type
+    -> typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>(), bool>::type
     {
         using common_type = _impl::common_type_t<Lhs, Rhs>;
         return static_cast<common_type>(lhs)!=static_cast<common_type>(rhs);
@@ -165,8 +114,7 @@ namespace sg14 {
 
     template<class Lhs, class Rhs>
     constexpr auto operator<(const Lhs& lhs, const Rhs& rhs)
-    -> typename std::enable_if<
-            _impl::is_fixed_point<Lhs>::value || _impl::is_fixed_point<Rhs>::value, bool>::type
+    -> typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>(), bool>::type
     {
         using common_type = _impl::common_type_t<Lhs, Rhs>;
         return static_cast<common_type>(lhs)<static_cast<common_type>(rhs);
@@ -174,8 +122,7 @@ namespace sg14 {
 
     template<class Lhs, class Rhs>
     constexpr auto operator>(const Lhs& lhs, const Rhs& rhs)
-    -> typename std::enable_if<
-            _impl::is_fixed_point<Lhs>::value || _impl::is_fixed_point<Rhs>::value, bool>::type
+    -> typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>(), bool>::type
     {
         using common_type = _impl::common_type_t<Lhs, Rhs>;
         return static_cast<common_type>(lhs)>static_cast<common_type>(rhs);
@@ -183,8 +130,7 @@ namespace sg14 {
 
     template<class Lhs, class Rhs>
     constexpr auto operator>=(const Lhs& lhs, const Rhs& rhs)
-    -> typename std::enable_if<
-            _impl::is_fixed_point<Lhs>::value || _impl::is_fixed_point<Rhs>::value, bool>::type
+    -> typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>(), bool>::type
     {
         using common_type = _impl::common_type_t<Lhs, Rhs>;
         return static_cast<common_type>(lhs)>=static_cast<common_type>(rhs);
@@ -192,8 +138,7 @@ namespace sg14 {
 
     template<class Lhs, class Rhs>
     constexpr auto operator<=(const Lhs& lhs, const Rhs& rhs)
-    -> typename std::enable_if<
-            _impl::is_fixed_point<Lhs>::value || _impl::is_fixed_point<Rhs>::value, bool>::type
+    -> typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>(), bool>::type
     {
         using common_type = _impl::common_type_t<Lhs, Rhs>;
         return static_cast<common_type>(lhs)<=static_cast<common_type>(rhs);
@@ -361,36 +306,6 @@ namespace sg14 {
         using result_type = _impl::common_type_t<fixed_point<RhsRep, RhsExponent>, LhsFloat>;
         return lhs/
                 static_cast<result_type>(rhs);
-    }
-
-    template<class LhsRep, int Exponent, class Rhs>
-    fixed_point<LhsRep, Exponent>& operator+=(fixed_point<LhsRep, Exponent>& lhs, const Rhs& rhs)
-    {
-        return lhs = static_cast<fixed_point<LhsRep, Exponent>>(lhs+rhs);
-    }
-
-    template<class LhsRep, int Exponent, class Rhs>
-    fixed_point<LhsRep, Exponent>& operator-=(fixed_point<LhsRep, Exponent>& lhs, const Rhs& rhs)
-    {
-        return lhs = static_cast<fixed_point<LhsRep, Exponent>>(lhs-rhs);
-    }
-
-    template<class LhsRep, int Exponent>
-    template<class Rhs>
-    fixed_point<LhsRep, Exponent>&
-    fixed_point<LhsRep, Exponent>::operator*=(const Rhs& rhs)
-    {
-        _r *= static_cast<rep>(rhs);
-        return *this;
-    }
-
-    template<class LhsRep, int Exponent>
-    template<class Rhs>
-    fixed_point<LhsRep, Exponent>&
-    fixed_point<LhsRep, Exponent>::operator/=(const Rhs& rhs)
-    {
-        _r /= static_cast<rep>(rhs);
-        return *this;
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/include/sg14/bits/fixed_point_type.h
+++ b/include/sg14/bits/fixed_point_type.h
@@ -12,7 +12,6 @@
 
 #if ! defined(SG14_GODBOLT_ORG)
 #include <sg14/cstdint>
-#include <sg14/limits>
 #include <sg14/auxiliary/const_integer.h>
 #include <sg14/bits/number_base.h>
 #endif

--- a/include/sg14/bits/number_base.h
+++ b/include/sg14/bits/number_base.h
@@ -1,0 +1,211 @@
+
+//          Copyright John McFarlane 2015 - 2017.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(SG14_number_base_H)
+#define SG14_number_base_H 1
+
+#include <type_traits>
+
+namespace sg14 {
+    namespace _impl {
+        template<class Derived, class Rep>
+        class number_base {
+            enum _from_data {
+                _from_data
+            };
+
+        public:
+            using rep = Rep;
+
+            number_base() = default;
+
+            template<class T>
+            constexpr number_base(const T& r)
+                : _rep(r) { }
+
+            explicit constexpr operator bool() const
+            {
+                return data() != rep{};
+            }
+
+            constexpr const rep& data() const
+            {
+                return _rep;
+            }
+
+            static constexpr Derived from_data(rep r)
+            {
+                return Derived(r);
+            }
+
+        private:
+            rep _rep;
+        };
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // sg14::_impl::is_number_base
+
+        template<class T, class Enable = void>
+        struct is_number_base : std::false_type {};
+
+        template<class Derived, class Rep>
+        struct is_number_base<number_base<Derived, Rep>> : std::true_type {
+        };
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // sg14::_impl::is_number
+
+        template<class T, class Enable = void>
+        struct is_number : std::false_type {};
+
+        template<class Derived>
+        struct is_number<Derived, typename std::enable_if<std::is_class<Derived>::value>::type> {
+            static constexpr bool value
+                    = std::is_base_of<number_base<Derived, typename Derived::rep>, Derived>::value;
+        };
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // sg14::_impl::number_base operators
+
+        // comparison
+
+        template<class Derived>
+        constexpr auto operator==(
+                const _impl::number_base<Derived, typename Derived::rep>& lhs,
+                const _impl::number_base<Derived, typename Derived::rep>& rhs)
+        -> typename std::enable_if<_impl::is_number<Derived>::value, bool>::type
+        {
+            return lhs.data()==rhs.data();
+        }
+
+        template<class Derived>
+        constexpr auto operator!=(
+                const _impl::number_base<Derived, typename Derived::rep>& lhs,
+                const _impl::number_base<Derived, typename Derived::rep>& rhs)
+        -> typename std::enable_if<_impl::is_number<Derived>::value, bool>::type
+        {
+            return lhs.data()!=rhs.data();
+        }
+
+        template<class Derived>
+        constexpr auto operator>(
+                const _impl::number_base<Derived, typename Derived::rep>& lhs,
+                const _impl::number_base<Derived, typename Derived::rep>& rhs)
+        -> typename std::enable_if<_impl::is_number<Derived>::value, bool>::type
+        {
+            return lhs.data()>rhs.data();
+        }
+
+        template<class Derived>
+        constexpr auto operator<(
+                const _impl::number_base<Derived, typename Derived::rep>& lhs,
+                const _impl::number_base<Derived, typename Derived::rep>& rhs)
+        -> typename std::enable_if<_impl::is_number<Derived>::value, bool>::type
+        {
+            return lhs.data()<rhs.data();
+        }
+
+        template<class Derived>
+        constexpr auto operator>=(
+                const _impl::number_base<Derived, typename Derived::rep>& lhs,
+                const _impl::number_base<Derived, typename Derived::rep>& rhs)
+        -> typename std::enable_if<_impl::is_number<Derived>::value, bool>::type
+        {
+            return lhs.data()>=rhs.data();
+        }
+
+        template<class Derived>
+        constexpr auto operator<=(
+                const _impl::number_base<Derived, typename Derived::rep>& lhs,
+                const _impl::number_base<Derived, typename Derived::rep>& rhs)
+        -> typename std::enable_if<_impl::is_number<Derived>::value, bool>::type
+        {
+            return lhs.data()<=rhs.data();
+        }
+
+        // compound assignment
+
+        template<class Lhs, class Rhs>
+        auto operator+=(Lhs& lhs, const Rhs& rhs)
+        -> typename std::enable_if<_impl::is_number<Lhs>::value, Lhs&>::type
+        {
+            return lhs = lhs + rhs;
+        }
+
+        template<class Lhs, class Rhs>
+        auto operator-=(Lhs& lhs, const Rhs& rhs)
+        -> typename std::enable_if<_impl::is_number<Lhs>::value, Lhs&>::type
+        {
+            return lhs = lhs - rhs;
+        }
+
+        template<class Lhs, class Rhs>
+        auto operator*=(Lhs& lhs, const Rhs& rhs)
+        -> typename std::enable_if<_impl::is_number<Lhs>::value, Lhs&>::type
+        {
+            return lhs = lhs * rhs;
+        }
+
+        template<class Lhs, class Rhs>
+        auto operator/=(Lhs& lhs, const Rhs& rhs)
+        -> typename std::enable_if<_impl::is_number<Lhs>::value, Lhs&>::type
+        {
+            return lhs = lhs / rhs;
+        }
+
+        // unary
+
+        template<class Rhs>
+        constexpr auto operator+(
+                const Rhs& rhs)
+        -> typename std::enable_if<_impl::is_number<Rhs>::value, Rhs>::type
+        {
+            return rhs;
+        }
+
+        template<class Rhs>
+        constexpr auto operator-(
+                const Rhs& rhs)
+        -> typename std::enable_if<_impl::is_number<Rhs>::value, Rhs>::type
+        {
+            return Rhs::from_data(-rhs.data());
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // sg14::rep
+
+    template<class Rep, class Enable = void>
+    struct rep;
+
+    template<class Rep>
+    struct rep<Rep, typename std::enable_if<!_impl::is_number<Rep>::value>::type> {
+        constexpr const Rep& operator()(const Rep& component) const
+        {
+            static_assert(!_impl::is_number<Rep>::value, "");
+            static_assert(!_impl::is_number_base<Rep>::value, "");
+            static_assert(!_impl::is_number<typename std::decay<Rep>::type>::value, "");
+            static_assert(!_impl::is_number_base<typename std::decay<Rep>::type>::value, "");
+            return component;
+        }
+    };
+
+    template<class Derived>
+    struct rep<Derived, typename std::enable_if<_impl::is_number<Derived>::value>::type> {
+        constexpr const typename Derived::rep& operator()(const Derived& component) const
+        {
+            return component.data();
+        }
+    };
+
+    template<class Component>
+    constexpr auto to_rep(Component&& component)
+    -> decltype(rep<typename std::decay<Component>::type>()(component)) {
+        return rep<typename std::decay<Component>::type>()(component);
+    }
+}
+
+#endif

--- a/include/sg14/bits/number_base.h
+++ b/include/sg14/bits/number_base.h
@@ -176,35 +176,77 @@ namespace sg14 {
     }
 
     ////////////////////////////////////////////////////////////////////////////////
-    // sg14::rep
+    // sg14::to_rep
 
-    template<class Rep, class Enable = void>
-    struct rep;
+    namespace _to_rep_impl {
+        template<class Rep, class Enable = void>
+        struct to_rep;
 
-    template<class Rep>
-    struct rep<Rep, typename std::enable_if<!_impl::is_number<Rep>::value>::type> {
-        constexpr const Rep& operator()(const Rep& component) const
-        {
-            static_assert(!_impl::is_number<Rep>::value, "");
-            static_assert(!_impl::is_number_base<Rep>::value, "");
-            static_assert(!_impl::is_number<typename std::decay<Rep>::type>::value, "");
-            static_assert(!_impl::is_number_base<typename std::decay<Rep>::type>::value, "");
-            return component;
-        }
-    };
+        template<class Rep>
+        struct to_rep<Rep, typename std::enable_if<!_impl::is_number<Rep>::value>::type> {
+            constexpr const Rep& operator()(const Rep& component) const
+            {
+                static_assert(!_impl::is_number<Rep>::value, "");
+                static_assert(!_impl::is_number_base<Rep>::value, "");
+                static_assert(!_impl::is_number<typename std::decay<Rep>::type>::value, "");
+                static_assert(!_impl::is_number_base<typename std::decay<Rep>::type>::value, "");
+                return component;
+            }
+        };
 
-    template<class Derived>
-    struct rep<Derived, typename std::enable_if<_impl::is_number<Derived>::value>::type> {
-        constexpr const typename Derived::rep& operator()(const Derived& component) const
-        {
-            return component.data();
-        }
-    };
+        template<class Derived>
+        struct to_rep<Derived, typename std::enable_if<_impl::is_number<Derived>::value>::type> {
+            constexpr const typename Derived::rep& operator()(const Derived& component) const
+            {
+                return component.data();
+            }
+        };
+    }
 
     template<class Component>
     constexpr auto to_rep(Component&& component)
-    -> decltype(rep<typename std::decay<Component>::type>()(component)) {
-        return rep<typename std::decay<Component>::type>()(component);
+    -> decltype(_to_rep_impl::to_rep<typename std::decay<Component>::type>()(component)) {
+        return _to_rep_impl::to_rep<typename std::decay<Component>::type>()(component);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // sg14::from_rep
+
+    namespace _from_rep_impl {
+        template<class Rep, class Enable = void>
+        struct from_rep;
+
+        template<class Rep>
+        struct from_rep<Rep, typename std::enable_if<!_impl::is_number<Rep>::value>::type> {
+            constexpr const Rep& operator()(const Rep& component) const
+            {
+                static_assert(!_impl::is_number<Rep>::value, "");
+                static_assert(!_impl::is_number_base<Rep>::value, "");
+                static_assert(!_impl::is_number<typename std::decay<Rep>::type>::value, "");
+                static_assert(!_impl::is_number_base<typename std::decay<Rep>::type>::value, "");
+                return component;
+            }
+        };
+
+        template<class Derived>
+        struct from_rep<Derived, typename std::enable_if<_impl::is_number<Derived>::value>::type> {
+            constexpr const Derived operator()(const typename Derived::rep& rep) const
+            {
+                return Derived::from_data(rep);
+            }
+        };
+    }
+
+    template<class Derived, class Rep>
+    constexpr auto from_rep(Rep const& rep)
+    -> decltype(_from_rep_impl::from_rep<Derived>()(rep)) {
+        return _from_rep_impl::from_rep<Derived>()(rep);
+    }
+
+    template<class Rep>
+    constexpr auto from_rep(Rep const& component)
+    -> Rep const& {
+        return component;
     }
 }
 

--- a/include/sg14/bits/number_base.h
+++ b/include/sg14/bits/number_base.h
@@ -7,6 +7,7 @@
 #if !defined(SG14_number_base_H)
 #define SG14_number_base_H 1
 
+#include <limits>
 #include <type_traits>
 
 namespace sg14 {
@@ -248,6 +249,67 @@ namespace sg14 {
     -> Rep const& {
         return component;
     }
+}
+
+namespace std {
+    ////////////////////////////////////////////////////////////////////////////////
+    // std::numeric_limits for sg14::_impl::numeric_limits
+
+    template<class Derived, class Rep>
+    struct numeric_limits<sg14::_impl::number_base<Derived, Rep>>
+    : numeric_limits<Rep> {
+        // fixed-point-specific helpers
+        using _value_type = Derived;
+        using _rep = typename _value_type::rep;
+        using _rep_numeric_limits = numeric_limits<_rep>;
+
+        // standard members
+
+        static constexpr _value_type min() noexcept
+        {
+            return sg14::from_rep<_value_type>(_rep_numeric_limits::min());
+        }
+
+        static constexpr _value_type max() noexcept
+        {
+            return _value_type::from_data(_rep_numeric_limits::max());
+        }
+
+        static constexpr _value_type lowest() noexcept
+        {
+            return _value_type::from_data(_rep_numeric_limits::lowest());
+        }
+
+        static constexpr _value_type epsilon() noexcept
+        {
+            return _value_type::from_data(_rep_numeric_limits::round_error());
+        }
+
+        static constexpr _value_type round_error() noexcept
+        {
+            return static_cast<_value_type>(_rep_numeric_limits::round_error());
+        }
+
+        static constexpr _value_type infinity() noexcept
+        {
+            return static_cast<_value_type>(_rep_numeric_limits::infinity());
+        }
+
+        static constexpr _value_type quiet_NaN() noexcept
+        {
+            return static_cast<_value_type>(_rep_numeric_limits::quiet_NaN());
+        }
+
+        static constexpr _value_type signaling_NaN() noexcept
+        {
+            return static_cast<_value_type>(_rep_numeric_limits::signaling_NaN());
+        }
+
+        static constexpr _value_type denorm_min() noexcept
+        {
+            return static_cast<_value_type>(_rep_numeric_limits::denorm_min());
+        }
+    };
 }
 
 #endif

--- a/src/common/common.cmake
+++ b/src/common/common.cmake
@@ -39,7 +39,7 @@ else ()
   message(FATAL_ERROR "unrecognized compiler: ${CMAKE_CXX_COMPILER_ID}")
 endif ()
 
-set(STD 14 CACHE BOOL "version of C++ standard: 11, 14 or 17 (experimental)")
+set(STD 14 CACHE STRING "version of C++ standard: 11, 14 or 17 (experimental)")
 if (${STD} STREQUAL "17")
     set(STD_FLAGS "${CPP17_ENABLED_FLAGS}")
 else ()

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(fp_test
         ${CMAKE_CURRENT_LIST_DIR}/p0037.cpp
         ${CMAKE_CURRENT_LIST_DIR}/p0381.cpp
         ${CMAKE_CURRENT_LIST_DIR}/p0554.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/precise_integer.cpp
         ${CMAKE_CURRENT_LIST_DIR}/utils.cpp
         ${CMAKE_CURRENT_LIST_DIR}/safe_integer.cpp
         ${CMAKE_CURRENT_LIST_DIR}/fixed_point_built_in.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(fp_test
         ${CMAKE_CURRENT_LIST_DIR}/p0554.cpp
         ${CMAKE_CURRENT_LIST_DIR}/precise_integer.cpp
         ${CMAKE_CURRENT_LIST_DIR}/utils.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/precise_safe_elastic_fixed_point.cpp
         ${CMAKE_CURRENT_LIST_DIR}/safe_integer.cpp
         ${CMAKE_CURRENT_LIST_DIR}/fixed_point_built_in.cpp
         ${CMAKE_CURRENT_LIST_DIR}/fixed_point_const_integer.cpp

--- a/src/test/elastic_integer.cpp
+++ b/src/test/elastic_integer.cpp
@@ -62,7 +62,7 @@ namespace {
         ////////////////////////////////////////////////////////////////////////////////
         // members
 
-        static constexpr int width = value_type::width;
+        static constexpr int width = sg14::width<value_type>::value;
         static constexpr int digits = value_type::digits;
         static constexpr bool is_signed = std::numeric_limits<narrowest>::is_signed;
         static_assert(width==digits+is_signed, "some of our bits are missing");

--- a/src/test/elastic_integer.cpp
+++ b/src/test/elastic_integer.cpp
@@ -18,6 +18,7 @@ namespace {
 
     // simple one-off tests
     static_assert(identical(-elastic_integer<1, unsigned>{1}, elastic_integer<1, signed>{-1}), "elastic_integer test failed");
+    static_assert(sg14::width<elastic_integer<7, int>>::value == 8, "elastic_integer test failed");
 
     namespace test_is_elastic_integer {
         using sg14::_elastic_integer_impl::is_elastic_integer;
@@ -46,7 +47,19 @@ namespace {
         static_assert(~elastic_integer<12, int>{0x050}==~0x50, "sg14::elastic_integer test failed");
         static_assert(~elastic_integer<12, unsigned>{0}==0xFFFU, "sg14::elastic_integer test failed");
         static_assert(~elastic_integer<7, std::int8_t>{0x5a}==~0x5a, "sg14::elastic_integer test failed");
-        static_assert(~elastic_integer<50, std::int64_t>{0x987654321LL}==~0x987654321LL, "sg14::elastic_integer test failed");
+        static_assert(~elastic_integer<50, std::int64_t>{INT64_C(0x987654321)}==~INT64_C(0x987654321), "sg14::elastic_integer test failed");
+    }
+
+    namespace test_multiply {
+        using sg14::make_elastic_integer;
+        static_assert(identical(elastic_integer<0>{0} * INT64_C(0), sg14::elastic_integer<63, int>{0}),
+                      "sg14::elastic_integer test failed");
+        static_assert(identical(make_elastic_integer(177_c), sg14::elastic_integer<8, int>{177}),
+                      "sg14::elastic_integer test failed");
+#if defined(SG14_INT128_ENABLED)
+        static_assert(identical(make_elastic_integer(177_c) * INT64_C(9218), sg14::elastic_integer<71, int>{1631586}),
+                      "sg14::elastic_integer test failed");
+#endif
     }
 
     // parameterized tests
@@ -114,7 +127,7 @@ namespace {
     struct elastic_integer_test<elastic_integer<0, int>, -1, 1, 0>;
 #if defined(SG14_INT128_ENABLED)
     template
-    struct elastic_integer_test<elastic_integer<39, unsigned int>, 0, 1, (1LL << 39)-1>;
+    struct elastic_integer_test<elastic_integer<39, unsigned int>, 0, 1, (INT64_C(1) << 39)-1>;
 #endif
 
     // user-defined literal initialization

--- a/src/test/fixed_point_common.h
+++ b/src/test/fixed_point_common.h
@@ -888,9 +888,9 @@ struct FixedPointTesterOutsize {
     // simply assignment to and from underlying representation
     using numeric_limits = std::numeric_limits<fixed_point>;
     static constexpr fixed_point min = fixed_point::from_data(rep(1));
+#if !defined(_MSC_VER)
     static_assert(min.data() == rep(1), "all Rep types should be able to store the number 1!");
 
-#if !defined(_MSC_VER)
     // unary common_type_t
     static_assert(is_same<
                     sg14::_impl::common_type_t<fixed_point>,

--- a/src/test/fixed_point_common.h
+++ b/src/test/fixed_point_common.h
@@ -755,6 +755,48 @@ static_assert(identical(divide(fixed_point<uint32, 0>{0xFFFE0001LL}, fixed_point
 ////////////////////////////////////////////////////////////////////////////////
 // std::numeric_limits<fixed_point<>>
 
+template<class Rep, int Exponent, class Min, class Max, class Lowest>
+constexpr bool test_numeric_limits(Min min, Max max, Lowest lowest)
+{
+    using fp = fixed_point<Rep, Exponent>;
+    using nl = numeric_limits<fp>;
+    using rnl = numeric_limits<Rep>;
+
+    static_assert(nl::is_specialized, "numeric_limits<fixed_point>::is_specialized");
+    static_assert(nl::is_signed==rnl::is_signed, "numeric_limits<fixed_point>::is_signed");
+    static_assert(!nl::is_integer, "numeric_limits<fixed_point>::is_integer");
+    static_assert(nl::is_exact, "numeric_limits<fixed_point>::is_exact");
+    static_assert(!nl::has_infinity, "numeric_limits<fixed_point>::has_infinity");
+    static_assert(!nl::has_quiet_NaN, "numeric_limits<fixed_point>::has_quiet_NaN");
+    static_assert(!nl::has_signaling_NaN, "numeric_limits<fixed_point>::has_signaling_NaN");
+    static_assert(!nl::has_denorm, "numeric_limits<fixed_point>::has_denorm");
+    static_assert(!nl::has_denorm_loss, "numeric_limits<fixed_point>::has_denorm_loss");
+    static_assert(nl::round_style==std::round_toward_zero, "numeric_limits<fixed_point>::round_style");
+    static_assert(!nl::is_iec559, "numeric_limits<fixed_point>::is_iec559");
+    static_assert(nl::is_bounded, "numeric_limits<fixed_point>::is_bounded");
+    static_assert(nl::is_modulo==rnl::is_modulo, "numeric_limits<fixed_point>::is_modulo");
+    static_assert(nl::digits==rnl::digits, "numeric_limits<fixed_point>::digits");
+    static_assert(nl::digits10==rnl::digits10, "numeric_limits<fixed_point>::digits10");
+    static_assert(nl::max_digits10==rnl::max_digits10, "numeric_limits<fixed_point>::max_digits10");
+    static_assert(nl::radix==2, "numeric_limits<fixed_point>::radix");
+    static_assert(nl::min_exponent==rnl::min_exponent, "numeric_limits<fixed_point>::min_exponent");
+    static_assert(nl::min_exponent10==rnl::min_exponent10, "numeric_limits<fixed_point>::min_exponent10");
+    static_assert(nl::max_exponent==rnl::max_exponent, "numeric_limits<fixed_point>::max_exponent");
+    static_assert(nl::max_exponent10==rnl::max_exponent10, "numeric_limits<fixed_point>::max_exponent10");
+    static_assert(nl::traps==rnl::traps, "numeric_limits<fixed_point>::traps");
+    static_assert(!nl::tinyness_before, "numeric_limits<fixed_point>::tinyness_before");
+    static_assert(nl::round_error()==static_cast<Rep>(.5), "numeric_limits<fixed_point>::round_error");
+    static_assert(nl::infinity()==rnl::infinity(), "numeric_limits<fixed_point>::infinity");
+    static_assert(nl::quiet_NaN()==0, "numeric_limits<fixed_point>::quiet_NaN");
+    static_assert(nl::signaling_NaN()==0, "numeric_limits<fixed_point>::signaling_NaN");
+
+    return nl::min()==min
+            && nl::lowest()==lowest
+            && nl::max()==max
+            && nl::epsilon()==min
+            && nl::denorm_min()==min;
+}
+
 static_assert(numeric_limits<fixed_point<test_int, -256>>::lowest() < -.1e-67, "std::numeric_limits<fixed_point> test failed");
 static_assert(numeric_limits<fixed_point<test_int, -256>>::min() > 0., "std::numeric_limits<fixed_point> test failed");
 static_assert(numeric_limits<fixed_point<test_int, -256>>::min() < .1e-76, "std::numeric_limits<fixed_point> test failed");
@@ -765,37 +807,29 @@ static_assert(numeric_limits<fixed_point<test_unsigned, -256>>::min() > 0., "std
 static_assert(numeric_limits<fixed_point<test_unsigned, -256>>::min() < .1e-76, "std::numeric_limits<fixed_point> test failed");
 static_assert(numeric_limits<fixed_point<test_unsigned, -256>>::max() > .1e-67, "std::numeric_limits<fixed_point> test failed");
 
-static_assert(numeric_limits<fixed_point<test_int, -16>>::lowest() == numeric_limits<test_int>::lowest() / 65536., "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_int, -16>>::min() == 1 / 65536., "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_int, -16>>::max() == numeric_limits<test_int>::max() / 65536., "std::numeric_limits<fixed_point> test failed");
+static_assert(test_numeric_limits<test_signed, -16>(1/65536.,
+        std::numeric_limits<test_signed>::max()/65536.,
+        std::numeric_limits<test_signed>::lowest()/65536.), "");
 
-#if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
-static_assert(numeric_limits<fixed_point<test_unsigned, -16>>::lowest() == 0, "std::numeric_limits<fixed_point> test failed");
-#endif
-static_assert(numeric_limits<fixed_point<test_unsigned, -16>>::min() == 1 / 65536., "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_unsigned, -16>>::max() == numeric_limits<test_unsigned>::max() / 65536., "std::numeric_limits<fixed_point> test failed");
+static_assert(test_numeric_limits<test_unsigned, -16>(1/65536.,
+        std::numeric_limits<test_unsigned>::max()/65536.,
+        std::numeric_limits<test_unsigned>::lowest()/65536.), "");
 
-#if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
-static_assert(numeric_limits<fixed_point<test_int, 0>>::lowest() == numeric_limits<test_int>::lowest(), "std::numeric_limits<fixed_point> test failed");
-#endif
-static_assert(numeric_limits<fixed_point<test_int, 0>>::min() == 1, "std::numeric_limits<fixed_point> test failed");
-#if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
-static_assert(numeric_limits<fixed_point<test_int, 0>>::max() == numeric_limits<test_int>::max(), "std::numeric_limits<fixed_point> test failed");
-#endif
+static_assert(test_numeric_limits<test_signed, 0>(1,
+        std::numeric_limits<test_signed>::max(),
+        std::numeric_limits<test_signed>::lowest()), "");
 
-static_assert(numeric_limits<fixed_point<test_unsigned, 0>>::lowest() == 0, "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_unsigned, 0>>::min() == 1, "std::numeric_limits<fixed_point> test failed");
-#if !defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS)
-static_assert(numeric_limits<fixed_point<test_unsigned, 0>>::max() == numeric_limits<test_unsigned>::max(), "std::numeric_limits<fixed_point> test failed");
+static_assert(test_numeric_limits<test_unsigned, 0>(1,
+        std::numeric_limits<test_unsigned>::max(),
+        std::numeric_limits<test_unsigned>::lowest()), "");
 
-static_assert(numeric_limits<fixed_point<test_int, 16>>::lowest() == numeric_limits<test_int>::lowest() * 65536LL, "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_int, 16>>::min() == 65536, "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_int, 16>>::max() == numeric_limits<test_int>::max() * 65536LL, "std::numeric_limits<fixed_point> test failed");
+static_assert(test_numeric_limits<test_signed, 16>(65536.,
+        std::numeric_limits<test_signed>::max()*65536.,
+        std::numeric_limits<test_signed>::lowest()*65536.), "");
 
-static_assert(numeric_limits<fixed_point<test_unsigned, 16>>::lowest() == 0, "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_unsigned, 16>>::min() == 65536, "std::numeric_limits<fixed_point> test failed");
-static_assert(numeric_limits<fixed_point<test_unsigned, 16>>::max() == numeric_limits<test_unsigned>::max() * 65536LL, "std::numeric_limits<fixed_point> test failed");
-#endif
+static_assert(test_numeric_limits<test_unsigned, 16>(65536.,
+        std::numeric_limits<test_unsigned>::max()*65536.,
+        std::numeric_limits<test_unsigned>::lowest()*65536.), "");
 
 static_assert(numeric_limits<fixed_point<test_int, 256>>::lowest() < -1.e86, "std::numeric_limits<fixed_point> test failed");
 static_assert(numeric_limits<fixed_point<test_int, 256>>::min() > 1.e77, "std::numeric_limits<fixed_point> test failed");

--- a/src/test/fixed_point_common.h
+++ b/src/test/fixed_point_common.h
@@ -637,7 +637,7 @@ static_assert(is_same<decltype(make_fixed<31, 32>(16777215.996093750)+765.432f),
         "sg14::fixed_point addition operator test failed");
 
 #if ! defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS_SATURATED) && ! defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS_NATIVE) && ! defined(TEST_IGNORE_MSVC_INTERNAL_ERRORS_THROWING)
-static_assert(identical(add(fixed_point<int32, -16>{.5}, 2), fixed_point<int64, -16>{2.5}),
+static_assert(identical(sg14::add(fixed_point<int32, -16>{.5}, 2), fixed_point<int64, -16>{2.5}),
         "sg14::fixed_point addition operator test failed");
 static_assert(identical(fixed_point<int32, -16>{.5} + 2, fixed_point<test_int, -16>{2.5}),
         "sg14::fixed_point addition operator test failed");

--- a/src/test/precise_integer.cpp
+++ b/src/test/precise_integer.cpp
@@ -1,0 +1,69 @@
+
+//          Copyright John McFarlane 2015 - 2017.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <sg14/auxiliary/precise_integer.h>
+#include <sg14/bits/common.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+    using sg14::precise_integer;
+    using std::is_same;
+    using sg14::_impl::identical;
+
+    namespace number_base_traits {
+        using sg14::_impl::number_base;
+        using sg14::_impl::is_number_base;
+        using sg14::_impl::is_number;
+
+        static_assert(!is_number_base<int>::value, "");
+        static_assert(is_number_base<number_base<precise_integer<>, int>>::value, "");
+        static_assert(!is_number_base<precise_integer<>>::value, "");
+
+        static_assert(!is_number<int>::value, "");
+        static_assert(!is_number<number_base<precise_integer<>, int>>::value, "");
+        static_assert(is_number<precise_integer<>>::value, "");
+    }
+
+    namespace default_parameters {
+        using sg14::closest_rounding_policy;
+
+        using default_rep = int;
+
+        template<typename T>
+        using default_policy = sg14::closest_rounding_policy<T>;
+
+        static_assert(is_same<precise_integer<>, precise_integer<default_rep, default_policy<default_rep>>>::value, "sg14::precise_integer parameter default test failed");
+
+        static_assert(is_same<precise_integer<>::rep, default_rep>::value, "sg14::precise_integer parameter default test failed");
+        static_assert(is_same<precise_integer<>::rounding, default_policy<default_rep>>::value, "sg14::precise_integer parameter default test failed");
+    }
+
+    namespace to_rep {
+        using sg14::to_rep;
+
+        static_assert(identical(123, to_rep(123)), "sg14::to_rep test failed");
+        static_assert(identical(321, to_rep(precise_integer<>{321})), "sg14::to_rep test failed");
+    }
+
+    namespace test_closest_rounding_policy {
+        using sg14::closest_rounding_policy;
+        static_assert(closest_rounding_policy<int>::convert(0.) == 0, "sg14::closest_rounding_policy test failed");
+        static_assert(closest_rounding_policy<int>::convert(-1.) == -1, "sg14::closest_rounding_policy test failed");
+    }
+
+    namespace closest {
+        using precise_integer = sg14::precise_integer<>;
+
+        static_assert(precise_integer{0.} == 0, "sg14::precise_integer test failed");
+        static_assert(precise_integer{1.} == 1, "sg14::precise_integer test failed");
+        static_assert(precise_integer{-1.} == -1, "sg14::precise_integer test failed");
+        static_assert(precise_integer{.5} == 1, "sg14::precise_integer test failed");
+        static_assert(precise_integer{-.5} == -1, "sg14::precise_integer test failed");
+        static_assert(precise_integer{0.499} == 0, "sg14::precise_integer test failed");
+        static_assert(precise_integer{-0.501} == -1, "sg14::precise_integer test failed");
+    }
+}

--- a/src/test/precise_safe_elastic_fixed_point.cpp
+++ b/src/test/precise_safe_elastic_fixed_point.cpp
@@ -1,0 +1,44 @@
+
+//          Copyright John McFarlane 2015 - 2017.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <sg14/fixed_point>
+#include <sg14/auxiliary/elastic_integer.h>
+#include <sg14/auxiliary/precise_integer.h>
+#include <sg14/auxiliary/safe_integer.h>
+
+namespace sg14 {
+    template<
+            int IntegerDigits,
+            int FractionalDigits = 0,
+            class OverflowPolicy = safe_integer<>::overflow,
+            class RoundingPolicy = precise_integer<>::rounding,
+            class Narrowest = int>
+    using precise_safe_elastic_fixed_point =
+    fixed_point<
+            precise_integer<
+                    safe_integer<
+                            elastic_integer<
+                                    IntegerDigits,
+                                    Narrowest>,
+                            OverflowPolicy>,
+                    RoundingPolicy>,
+            -FractionalDigits>;
+}
+
+namespace {
+    using sg14::precise_safe_elastic_fixed_point;
+    using std::is_same;
+
+    namespace default_parameters {
+        using sg14::precise_integer;
+        using sg14::safe_integer;
+        using sg14::elastic_integer;
+
+        static_assert(
+                is_same<precise_safe_elastic_fixed_point<0>::rep::rep::rep::rep, int>::value,
+                "sg14::precise_integer parameter default test failed");
+    }
+}

--- a/src/test/safe_integer.cpp
+++ b/src/test/safe_integer.cpp
@@ -379,3 +379,48 @@ static_assert(is_same<make_unsigned<saturated_integer<int64_t>>::type, saturated
         "sg14::make_unsigned<sg14::saturated_integer<>> test failed");
 static_assert(is_same<make_unsigned<saturated_integer<uint64_t>>::type, saturated_integer<uint64_t>>::value,
         "sg14::make_unsigned<sg14::saturated_integer<>> test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+// common safe_integer characteristics
+
+namespace {
+    template<class Rep, class Overflow>
+    struct test_common {
+        using safe_integer = sg14::safe_integer<Rep, Overflow>;
+
+        static_assert(is_same<typename safe_integer::rep, Rep>::value, "sg14::safe_integer test failed");
+        static_assert(is_same<typename safe_integer::overflow, Overflow>::value, "sg14::safe_integer test failed");
+
+        static constexpr auto default_initialized = safe_integer{};
+        static_assert(default_initialized == 0, "sg14::safe_integer test failed");
+
+        static_assert(+default_initialized == default_initialized, "sg14::safe_integer test failed");
+        static_assert(-default_initialized == default_initialized, "sg14::safe_integer test failed");
+        static_assert(default_initialized+default_initialized == default_initialized, "sg14::safe_integer test failed");
+        static_assert(default_initialized-default_initialized == default_initialized, "sg14::safe_integer test failed");
+        static_assert(default_initialized*default_initialized == default_initialized, "sg14::safe_integer test failed");
+        static_assert(default_initialized/1 == default_initialized, "sg14::safe_integer test failed");
+    };
+
+    template<class Rep>
+    struct test_common_for_rep
+            : test_common<Rep, sg14::native_overflow_policy>
+#if defined(SG14_EXCEPTIONS_ENABLED)
+            , test_common<Rep, sg14::throwing_overflow_policy>
+#endif
+            , test_common<Rep, sg14::saturated_overflow_policy> {
+    };
+
+    template struct test_common_for_rep<bool>;
+    template struct test_common_for_rep<char>;
+    template struct test_common_for_rep<unsigned char>;
+    template struct test_common_for_rep<signed char>;
+    template struct test_common_for_rep<unsigned short>;
+    template struct test_common_for_rep<signed short>;
+    template struct test_common_for_rep<unsigned>;
+    template struct test_common_for_rep<signed>;
+    template struct test_common_for_rep<unsigned long>;
+    template struct test_common_for_rep<signed long>;
+    template struct test_common_for_rep<unsigned long long>;
+    template struct test_common_for_rep<signed long long>;
+}

--- a/src/test/safe_integer.cpp
+++ b/src/test/safe_integer.cpp
@@ -395,7 +395,9 @@ namespace {
         static_assert(default_initialized == 0, "sg14::safe_integer test failed");
 
         static_assert(+default_initialized == default_initialized, "sg14::safe_integer test failed");
+#if !defined(_MSC_VER)
         static_assert(-default_initialized == default_initialized, "sg14::safe_integer test failed");
+#endif
         static_assert(default_initialized+default_initialized == default_initialized, "sg14::safe_integer test failed");
         static_assert(default_initialized-default_initialized == default_initialized, "sg14::safe_integer test failed");
         static_assert(default_initialized*default_initialized == default_initialized, "sg14::safe_integer test failed");
@@ -411,7 +413,6 @@ namespace {
             , test_common<Rep, sg14::saturated_overflow_policy> {
     };
 
-    template struct test_common_for_rep<bool>;
     template struct test_common_for_rep<char>;
     template struct test_common_for_rep<unsigned char>;
     template struct test_common_for_rep<signed char>;


### PR DESCRIPTION
Adds `sg14::_impl::number_base` which cuts down on duplication of various definitions including compound assignment and comparison operators. 

- `sg14::fixed_point`, `sg14::safe_integer` and `sg14::elastic_integer` are derived from `number_base`, as is new (incomplete) type, `precise_integer`. 
- Free functions `from_rep` and `to_rep` are intended as general-purpose replacements for `from_data` and `to_data`.
- `std::numeric_limits<number_base>` will provide the base class for specializations also.