### PR TITLE
don't return bool from comparison functions

### DIFF
--- a/include/sg14/auxiliary/elastic_integer.h
+++ b/include/sg14/auxiliary/elastic_integer.h
@@ -229,30 +229,20 @@ namespace sg14 {
         return lhs.data() OP rhs.data(); \
     } \
  \
-    template<int LhsDigits, class LhsNarrowest, class RhsInteger> \
-    constexpr auto operator OP (const elastic_integer<LhsDigits, LhsNarrowest>& lhs, const RhsInteger& rhs) \
-    -> typename std::enable_if<std::numeric_limits<RhsInteger>::is_integer, decltype(lhs.data() OP rhs)>::type \
+    template< \
+        int LhsDigits, class LhsNarrowest, class Rhs, \
+        typename std::enable_if<std::numeric_limits<Rhs>::is_integer || std::is_floating_point<Rhs>::value, int>::type = 0> \
+    constexpr auto operator OP (const elastic_integer<LhsDigits, LhsNarrowest>& lhs, const Rhs& rhs) \
+    -> decltype(lhs.data() OP rhs) \
     { \
         return lhs.data() OP rhs; \
     } \
  \
-    template<int LhsDigits, class LhsNarrowest, class RhsFloat> \
-    constexpr auto operator OP (const elastic_integer<LhsDigits, LhsNarrowest>& lhs, const RhsFloat& rhs) \
-    -> typename std::enable_if<std::is_floating_point<RhsFloat>::value, decltype(lhs.data() OP rhs)>::type \
-    { \
-        return lhs.data() OP rhs; \
-    } \
- \
-    template<class LhsInteger, int RhsDigits, class RhsNarrowest> \
-    constexpr auto operator OP (const LhsInteger& lhs, const elastic_integer<RhsDigits, RhsNarrowest>& rhs) \
-    -> typename std::enable_if<std::numeric_limits<LhsInteger>::is_integer, decltype(lhs OP rhs.data())>::type \
-    { \
-        return lhs OP rhs.data(); \
-    } \
- \
-    template<class LhsFloat, int RhsDigits, class RhsNarrowest> \
-    constexpr auto operator OP (const LhsFloat& lhs, const elastic_integer<RhsDigits, RhsNarrowest>& rhs) \
-    -> typename std::enable_if<std::is_floating_point<LhsFloat>::value, decltype(lhs OP rhs.data())>::type \
+    template< \
+        class Lhs, int RhsDigits, class RhsNarrowest, \
+        typename std::enable_if<std::numeric_limits<Lhs>::is_integer || std::is_floating_point<Lhs>::value, unsigned>::type = 0> \
+    constexpr auto operator OP (const Lhs& lhs, const elastic_integer<RhsDigits, RhsNarrowest>& rhs) \
+    -> decltype(lhs OP rhs.data()) \
     { \
         return lhs OP rhs.data(); \
     }

--- a/include/sg14/bits/fixed_point_operators.h
+++ b/include/sg14/bits/fixed_point_operators.h
@@ -96,52 +96,58 @@ namespace sg14 {
         }
     }
 
-    template<class Lhs, class Rhs>
+    template<
+            class Lhs, class Rhs,
+            class = typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>()>::type>
     constexpr auto operator==(const Lhs& lhs, const Rhs& rhs)
-    -> typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>(), bool>::type
+    -> decltype(static_cast<_impl::common_type_t<Lhs, Rhs>>(lhs)==static_cast<_impl::common_type_t<Lhs, Rhs>>(rhs))
     {
-        using common_type = _impl::common_type_t<Lhs, Rhs>;
-        return static_cast<common_type>(lhs)==static_cast<common_type>(rhs);
+        return static_cast<_impl::common_type_t<Lhs, Rhs>>(lhs)==static_cast<_impl::common_type_t<Lhs, Rhs>>(rhs);
     }
 
-    template<class Lhs, class Rhs>
+    template<
+            class Lhs, class Rhs,
+            class = typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>()>::type>
     constexpr auto operator!=(const Lhs& lhs, const Rhs& rhs)
-    -> typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>(), bool>::type
+    -> decltype(static_cast<_impl::common_type_t<Lhs, Rhs>>(lhs)!=static_cast<_impl::common_type_t<Lhs, Rhs>>(rhs))
     {
-        using common_type = _impl::common_type_t<Lhs, Rhs>;
-        return static_cast<common_type>(lhs)!=static_cast<common_type>(rhs);
+        return static_cast<_impl::common_type_t<Lhs, Rhs>>(lhs)!=static_cast<_impl::common_type_t<Lhs, Rhs>>(rhs);
     }
 
-    template<class Lhs, class Rhs>
+    template<
+            class Lhs, class Rhs,
+            class = typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>()>::type>
     constexpr auto operator<(const Lhs& lhs, const Rhs& rhs)
-    -> typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>(), bool>::type
+    -> decltype(static_cast<_impl::common_type_t<Lhs, Rhs>>(lhs)<static_cast<_impl::common_type_t<Lhs, Rhs>>(rhs))
     {
-        using common_type = _impl::common_type_t<Lhs, Rhs>;
-        return static_cast<common_type>(lhs)<static_cast<common_type>(rhs);
+        return static_cast<_impl::common_type_t<Lhs, Rhs>>(lhs)<static_cast<_impl::common_type_t<Lhs, Rhs>>(rhs);
     }
 
-    template<class Lhs, class Rhs>
+    template<
+            class Lhs, class Rhs,
+            class = typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>()>::type>
     constexpr auto operator>(const Lhs& lhs, const Rhs& rhs)
-    -> typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>(), bool>::type
+    -> decltype(static_cast<_impl::common_type_t<Lhs, Rhs>>(lhs)>static_cast<_impl::common_type_t<Lhs, Rhs>>(rhs))
     {
-        using common_type = _impl::common_type_t<Lhs, Rhs>;
-        return static_cast<common_type>(lhs)>static_cast<common_type>(rhs);
+        return static_cast<_impl::common_type_t<Lhs, Rhs>>(lhs)>static_cast<_impl::common_type_t<Lhs, Rhs>>(rhs);
     }
 
-    template<class Lhs, class Rhs>
+    template<
+            class Lhs, class Rhs,
+            class = typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>()>::type>
     constexpr auto operator>=(const Lhs& lhs, const Rhs& rhs)
-    -> typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>(), bool>::type
+    -> decltype(static_cast<_impl::common_type_t<Lhs, Rhs>>(lhs)>=static_cast<_impl::common_type_t<Lhs, Rhs>>(rhs))
     {
-        using common_type = _impl::common_type_t<Lhs, Rhs>;
-        return static_cast<common_type>(lhs)>=static_cast<common_type>(rhs);
+        return static_cast<_impl::common_type_t<Lhs, Rhs>>(lhs)>=static_cast<_impl::common_type_t<Lhs, Rhs>>(rhs);
     }
 
-    template<class Lhs, class Rhs>
+    template<
+            class Lhs, class Rhs,
+            class = typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>()>::type>
     constexpr auto operator<=(const Lhs& lhs, const Rhs& rhs)
-    -> typename std::enable_if<_fixed_point_operators_impl::is_heterogeneous<Lhs, Rhs>(), bool>::type
+    -> decltype(static_cast<_impl::common_type_t<Lhs, Rhs>>(lhs)<=static_cast<_impl::common_type_t<Lhs, Rhs>>(rhs))
     {
-        using common_type = _impl::common_type_t<Lhs, Rhs>;
-        return static_cast<common_type>(lhs)<=static_cast<common_type>(rhs);
+        return static_cast<_impl::common_type_t<Lhs, Rhs>>(lhs)<=static_cast<_impl::common_type_t<Lhs, Rhs>>(rhs);
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/include/sg14/bits/number_base.h
+++ b/include/sg14/bits/number_base.h
@@ -73,56 +73,68 @@ namespace sg14 {
 
         // comparison
 
-        template<class Derived>
+        template<
+                class Derived,
+                typename = std::enable_if<_impl::is_number<Derived>::value>>
         constexpr auto operator==(
                 const _impl::number_base<Derived, typename Derived::rep>& lhs,
                 const _impl::number_base<Derived, typename Derived::rep>& rhs)
-        -> typename std::enable_if<_impl::is_number<Derived>::value, bool>::type
+        -> decltype(lhs.data()==rhs.data())
         {
             return lhs.data()==rhs.data();
         }
 
-        template<class Derived>
+        template<
+                class Derived,
+                typename = std::enable_if<_impl::is_number<Derived>::value>>
         constexpr auto operator!=(
                 const _impl::number_base<Derived, typename Derived::rep>& lhs,
                 const _impl::number_base<Derived, typename Derived::rep>& rhs)
-        -> typename std::enable_if<_impl::is_number<Derived>::value, bool>::type
+        -> decltype(lhs.data()!=rhs.data())
         {
             return lhs.data()!=rhs.data();
         }
 
-        template<class Derived>
+        template<
+                class Derived,
+                typename = std::enable_if<_impl::is_number<Derived>::value>>
         constexpr auto operator>(
                 const _impl::number_base<Derived, typename Derived::rep>& lhs,
                 const _impl::number_base<Derived, typename Derived::rep>& rhs)
-        -> typename std::enable_if<_impl::is_number<Derived>::value, bool>::type
+        -> decltype(lhs.data()>rhs.data())
         {
             return lhs.data()>rhs.data();
         }
 
-        template<class Derived>
+        template<
+                class Derived,
+                typename = std::enable_if<_impl::is_number<Derived>::value>>
         constexpr auto operator<(
                 const _impl::number_base<Derived, typename Derived::rep>& lhs,
                 const _impl::number_base<Derived, typename Derived::rep>& rhs)
-        -> typename std::enable_if<_impl::is_number<Derived>::value, bool>::type
+        -> decltype(lhs.data()<=rhs.data())
         {
             return lhs.data()<rhs.data();
         }
 
-        template<class Derived>
+        template<
+                class Derived,
+                typename = std::enable_if<_impl::is_number<Derived>::value>>
         constexpr auto operator>=(
                 const _impl::number_base<Derived, typename Derived::rep>& lhs,
                 const _impl::number_base<Derived, typename Derived::rep>& rhs)
-        -> typename std::enable_if<_impl::is_number<Derived>::value, bool>::type
+        -> decltype(lhs.data()>=rhs.data())
         {
             return lhs.data()>=rhs.data();
         }
 
-        template<class Derived>
+        template<
+                class Derived,
+                typename = std::enable_if<_impl::is_number<Derived>::value>>
         constexpr auto operator<=(
                 const _impl::number_base<Derived, typename Derived::rep>& lhs,
                 const _impl::number_base<Derived, typename Derived::rep>& rhs)
-        -> typename std::enable_if<_impl::is_number<Derived>::value, bool>::type
+        -> decltype(lhs.data()<=rhs.data())
         {
             return lhs.data()<=rhs.data();
         }


### PR DESCRIPTION
- instead use decltype
- suggested by @jfalcou
- cuts down some duplication in elastic_integer macros