### PR TITLE
Safft fixes

### DIFF
--- a/.travis-setup-linux.sh
+++ b/.travis-setup-linux.sh
@@ -7,6 +7,7 @@ sudo apt-get update -qq
 
 # Install
 sudo apt-get install -qq cmake
+cmake --version
 
 # Ubuntu 14.04 defaults to Boost v54 which doesn't work without RTTI
 if [[ "$EXCEPTIONS" == "ON" ]]; then

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ and [Debian GNU/Linux 8.3](https://www.debian.org/releases/stable/) using GCC 5.
 Requires:
 
 - G++ 5.4
-- [CMake](https://cmake.org/download/) 2.8.11
+- [CMake](https://cmake.org/download/) 3.2
 
 Optional:
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -22,7 +22,8 @@ target_sources(fixed_point INTERFACE
         include/sg14/cstdint
         include/sg14/fixed_point
         include/sg14/limits
-        include/sg14/type_traits)
+        include/sg14/type_traits
+)
 
 include_directories(SYSTEM ${CMAKE_CURRENT_LIST_DIR})
 install(

--- a/src/test/safft.cpp
+++ b/src/test/safft.cpp
@@ -49,16 +49,18 @@ TEST(safft, fft_fixed_point)
     unsigned int impulseLoc =15; //Some index smaller than fftSize
     double twopi = M_PI*2.0;
 
-    fixed_point<int32_t,-16> zero = static_cast<fixed_point<int32_t,-16>>(0);
-    fixed_point<int32_t,-16> one = static_cast<fixed_point<int32_t,-16>>(1);
-    std::complex<fixed_point<int32_t,-16> > czero = std::complex<fixed_point<int32_t,-16>> (zero,zero);
-    std::complex<fixed_point<int32_t,-16> > cone = std::complex<fixed_point<int32_t,-16>> (one,zero);
+    using elastic_fixed_point = sg14::elastic_fixed_point<14, 16>;
+    using complex = std::complex<elastic_fixed_point>;
+    elastic_fixed_point zero = 0;
+    elastic_fixed_point one = 1;
+    complex czero = complex (zero,zero);
+    complex cone = complex (one,zero);
 
-    std::vector <std::complex<fixed_point<int32_t,-16> > > fix_vec1(fftSize, czero);
+    std::vector <complex> fix_vec1(fftSize, czero);
     fix_vec1[impulseLoc] = cone;
-    std::vector <std::complex<fixed_point<int32_t,-16> > > fix_vec2(fftSize, czero);
+    std::vector <complex> fix_vec2(fftSize, czero);
 
-    Algorithms::SaFFT<fixed_point<int32_t,-16>> fix_engine(fftSize);
+    Algorithms::SaFFT<elastic_fixed_point> fix_engine(fftSize);
 
     unsigned int fix_ret = fix_engine.fft(fix_vec1, fix_vec2);
     auto fix_ptr = (fix_ret == 0) ? &fix_vec1[0] : &fix_vec2[0];
@@ -84,16 +86,17 @@ TEST(safft, fft_elastic_fixed_point)
     unsigned int impulseLoc = 15; //Some index smaller than fftSize
     double twopi = M_PI*2.0;
 
-    elastic_fixed_point<16,16> zero = static_cast<elastic_fixed_point<16,16>>(0);
-    elastic_fixed_point<16,16> one = static_cast<elastic_fixed_point<16,16>>(1);
-    std::complex<elastic_fixed_point<16,16> > czero = std::complex<elastic_fixed_point<16,16>> (zero,zero);
-    std::complex<elastic_fixed_point<16,16> > cone = std::complex<elastic_fixed_point<16,16>> (one,zero);
+    using elastic_fixed_point = sg14::elastic_fixed_point<14, 16>;
+    elastic_fixed_point zero = static_cast<elastic_fixed_point>(0);
+    elastic_fixed_point one = static_cast<elastic_fixed_point>(1);
+    std::complex<elastic_fixed_point > czero = std::complex<elastic_fixed_point> (zero,zero);
+    std::complex<elastic_fixed_point > cone = std::complex<elastic_fixed_point> (one,zero);
 
-    std::vector <std::complex<elastic_fixed_point<16,16> > > vec1(fftSize, czero);
+    std::vector <std::complex<elastic_fixed_point > > vec1(fftSize, czero);
     vec1[impulseLoc] = cone;
-    std::vector <std::complex<elastic_fixed_point<16,16> > > vec2(fftSize, czero);
+    std::vector <std::complex<elastic_fixed_point > > vec2(fftSize, czero);
 
-    Algorithms::SaFFT<elastic_fixed_point<16,16>> fix_engine(fftSize);
+    Algorithms::SaFFT<elastic_fixed_point> fix_engine(fftSize);
 
     unsigned int ret = fix_engine.fft(vec1, vec2);
     auto ptr = (ret == 0) ? &vec1[0] : &vec2[0];

--- a/src/test/safft.cpp
+++ b/src/test/safft.cpp
@@ -4,6 +4,7 @@
 //  (See accompanying file ../../LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
+#define _USE_MATH_DEFINES // define M_PI in <cmath>
 
 #include <iostream>
 #include <iomanip>

--- a/src/test/safft.cpp
+++ b/src/test/safft.cpp
@@ -39,7 +39,7 @@ TEST(safft, fft_double)
         ref_angle = twopi*(double)index/(double)fftSize;
         ref = std::complex<double>(cos(ref_angle),-sin(ref_angle));
         //This will be pretty accurate...
-        ASSERT_EQ(std::abs(ptr[i]-ref)<0.00000000000001,1);
+        ASSERT_LT(std::abs(ptr[i]-ref), 0.00000000000001);
     }
 }
 
@@ -73,8 +73,8 @@ TEST(safft, fft_fixed_point)
         ref = std::complex<double>(cos(ref_angle),-sin(ref_angle));
         //Accuracy vs. double will be smaller
         //TODO: Acceptable FFT accuracy
-        ASSERT_EQ(std::abs((double)fix_ptr[i].real()-ref.real())<0.0005,1);
-        ASSERT_EQ(std::abs((double)fix_ptr[i].imag()-ref.imag())<0.0005,1);
+        ASSERT_LT(std::abs((double)fix_ptr[i].real()-ref.real()), 0.0005);
+        ASSERT_LT(std::abs((double)fix_ptr[i].imag()-ref.imag()), 0.0005);
     }
 }
 
@@ -108,7 +108,7 @@ TEST(safft, fft_elastic_fixed_point)
         ref = std::complex<double>(cos(ref_angle),-sin(ref_angle));
         //Accuracy vs. double will be smaller
         //TODO: Acceptable FFT accuracy
-        ASSERT_EQ(std::abs((double)ptr[i].real()-ref.real())<0.0005,1);
-        ASSERT_EQ(std::abs((double)ptr[i].imag()-ref.imag())<0.0005,1);
+        ASSERT_LT(std::abs((double)ptr[i].real()-ref.real()), 0.0005);
+        ASSERT_LT(std::abs((double)ptr[i].imag()-ref.imag()), 0.0005);
     }
 }

--- a/src/test/safft.h
+++ b/src/test/safft.h
@@ -92,21 +92,22 @@ namespace Algorithms {
     SaFFT<T>::~SaFFT() {
     }
 
-    template<class T>
-    unsigned int fft_core(std::vector<std::complex<T>> &vec1,
-                          std::vector<std::complex<T>> &vec2,
-                          std::vector<std::complex<T>> &twiddles,
-                          int direction_flag,
-                          typename std::enable_if<sg14::_impl::is_fixed_point<T>::value>::type *dummy __attribute__((unused)) = 0) {
+    template<class Rep, int Exponent>
+    unsigned int fft_core(std::vector<std::complex<sg14::fixed_point<Rep, Exponent>>> &vec1,
+                          std::vector<std::complex<sg14::fixed_point<Rep, Exponent>>> &vec2,
+                          std::vector<std::complex<sg14::fixed_point<Rep, Exponent>>> &twiddles,
+                          int direction_flag) {
+        using fixed_point = sg14::fixed_point<Rep, Exponent>;
+        using complex = std::complex<fixed_point>;
         unsigned int N = (unsigned int) vec1.size();
         unsigned int S = (unsigned int) (std::log10((double) N) /
                                          std::log10((double) 2));
         unsigned int stride = ((unsigned int) twiddles.size()) * 2 / N;
 
         unsigned int r, L_s, r_s;
-        std::complex<T> w, tau;
+        complex w, tau;
 
-        std::complex<T> *xp, *yp, *tp;
+        complex *xp, *yp, *tp;
         yp = &vec1[0]; //Initial input buffer
         xp = &vec2[0]; //Initial output buffer
 
@@ -126,22 +127,22 @@ namespace Algorithms {
                     xp[(j + L_s) * r + k] = yp[j * r_s + k] - tau; //FAILS
 #else //CALCULATE_WITH_COMPLEX_DATATYPE
 #ifdef USE_MULTIPLY_OPERATOR
-                    tau = std::complex<T>(
+                    tau = complex(
                             w.real()*yp[j * r_s + k + r].real() -
                             w.imag()*yp[j * r_s + k + r].imag(),
                             w.imag()*yp[j * r_s + k + r].real() +
                             w.real()*yp[j * r_s + k + r].imag());
 #else //USE_MULTIPLY_OPERATOR
-                    tau = std::complex<T>(
+                    tau = complex(
                             multiply(w.real(), yp[j * r_s + k + r].real()) -
                             multiply(w.imag(), yp[j * r_s + k + r].imag()),
                             multiply(w.imag(), yp[j * r_s + k + r].real()) +
                             multiply(w.real(), yp[j * r_s + k + r].imag()));
 #endif //USE_MULTIPLY_OPERATOR
-                    xp[j * r + k] = std::complex<T>(
+                    xp[j * r + k] = complex(
                             yp[j * r_s + k].real() + tau.real(),
                             yp[j * r_s + k].imag() + tau.imag());
-                    xp[(j + L_s) * r + k] = std::complex<T>(
+                    xp[(j + L_s) * r + k] = complex(
                             yp[j * r_s + k].real() - tau.real(),
                             yp[j * r_s + k].imag() - tau.imag());
 #endif //CALCULATE_WITH_COMPLEX_DATATYPE
@@ -161,8 +162,7 @@ namespace Algorithms {
     unsigned int fft_core(std::vector<std::complex<T>> &vec1,
                           std::vector<std::complex<T>> &vec2,
                           std::vector<std::complex<T>> &twiddles,
-                          int direction_flag,
-                          typename std::enable_if<std::is_floating_point<T>::value>::type *dummy __attribute__((unused)) = 0) {
+                          int direction_flag) {
         unsigned int N = (unsigned int) vec1.size();
         unsigned int S = (unsigned int) (std::log10((double) N) /
                                          std::log10((double) 2));

--- a/src/test/safft.h
+++ b/src/test/safft.h
@@ -16,8 +16,6 @@
 //#define CALCULATE_WITH_COMPLEX_DATATYPE
 //#define USE_MULTIPLY_OPERATOR
 
-using namespace sg14;
-
 namespace Algorithms {
 
 /**


### PR DESCRIPTION
Fixes required to get safft module to pass GitHub integration tests. 

Note: it's now possible to define `USE_MULTIPLY_OPERATOR` in *safft.h*.