### PR TITLE
fixes compiler error in const_integer ctor

### DIFF
--- a/include/sg14/auxiliary/elastic_integer.h
+++ b/include/sg14/auxiliary/elastic_integer.h
@@ -125,7 +125,7 @@ namespace sg14 {
                 : _base(static_cast<rep>(Value))
         {
             static_assert(Value <= std::numeric_limits<rep>::max(), "initialization by out-of-range value");
-            static_assert(Value >= std::numeric_limits<rep>::lowest(), "initialization by out-of-range value");
+            static_assert(!std::numeric_limits<Integral>::is_signed || Value >= std::numeric_limits<rep>::lowest(), "initialization by out-of-range value");
         }
 
         /// copy assignment operator taking a floating-point type

--- a/src/test/elastic_integer.cpp
+++ b/src/test/elastic_integer.cpp
@@ -63,9 +63,17 @@ namespace {
                 "sg14::elastic_integer test failed");
     }
 
-    static_assert(identical(elastic_integer<8>{1L}, elastic_integer<8>{1}), "elastic_integer test failed");
-    static_assert(identical(-elastic_integer<1, unsigned>{1}, elastic_integer<1, signed>{-1}), "elastic_integer test failed");
-    static_assert(sg14::width<elastic_integer<7, int>>::value == 8, "elastic_integer test failed");
+    namespace test_width {
+        static_assert(sg14::width<elastic_integer<7, int>>::value == 8, "elastic_integer test failed");
+    }
+
+    namespace test_ctor {
+        static_assert(identical(elastic_integer<8>{1L}, elastic_integer<8>{1}), "elastic_integer test failed");
+        static_assert(identical(-elastic_integer<1, unsigned>{1}, elastic_integer<1, signed>{-1}), "elastic_integer test failed");
+
+        static_assert(identical(elastic_integer<4>{10_c}, elastic_integer<4>{10}), "");
+        static_assert(identical(elastic_integer<10>{sg14::const_integer<unsigned, 1000>{}}, elastic_integer<10>{1000}), "");
+    }
 
     namespace test_is_elastic_integer {
         using sg14::_elastic_integer_impl::is_elastic_integer;


### PR DESCRIPTION
- caused by static_assert which fires incorrectly when input is unsigned