### PR TITLE
Switch to canonical invocation of 'tail'.

### DIFF
--- a/src/single_header/CMakeLists.txt
+++ b/src/single_header/CMakeLists.txt
@@ -12,7 +12,7 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang OR ${CMAKE_CXX_COMPILER_ID} STREQUAL
     add_custom_target(single_header
             ALL
             cat ${CMAKE_CURRENT_LIST_DIR}/header.h > ${SINGLE_HEADER_OUTPUT}
-            COMMAND ${CMAKE_CXX_COMPILER} ${COMMON_CXX_FLAGS_LIST} -E -I ${CMAKE_CURRENT_LIST_DIR}/../../include ${CMAKE_CURRENT_LIST_DIR}/single_header.cpp | grep "^[^#]" | grep --after-context=1000000 single_header_delimiter | tail +2 - >> ${SINGLE_HEADER_OUTPUT}
+            COMMAND ${CMAKE_CXX_COMPILER} ${COMMON_CXX_FLAGS_LIST} -E -I ${CMAKE_CURRENT_LIST_DIR}/../../include ${CMAKE_CURRENT_LIST_DIR}/single_header.cpp | grep "^[^#]" | grep --after-context=1000000 single_header_delimiter | tail -n +2 - >> ${SINGLE_HEADER_OUTPUT}
             COMMAND cat ${CMAKE_CURRENT_LIST_DIR}/footer.h >> ${SINGLE_HEADER_OUTPUT}
             )
 endif ()


### PR DESCRIPTION
'tail +2' does not work with the GNU version of tail, use 'tail -n +2', which does.
I'm not sure if there is some platform out there where this form does not work.