### PR TITLE
removes mention of __builtin_clz from single_header/fixed_point.h

### DIFF
--- a/include/sg14/auxiliary/numeric.h
+++ b/include/sg14/auxiliary/numeric.h
@@ -130,7 +130,7 @@ namespace sg14 {
     ////////////////////////////////////////////////////////////////////////////////
     // sg14::leading_bits
 
-#if !defined(_MSC_VER)
+#if !defined(_MSC_VER) && !defined(SG14_DISABLE_GCC_BUILTINS)
     constexpr int leading_bits(int value)
     {
         return (value>0)

--- a/src/single_header/CMakeLists.txt
+++ b/src/single_header/CMakeLists.txt
@@ -7,7 +7,7 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang OR ${CMAKE_CXX_COMPILER_ID} STREQUAL
     # add a target to generate preprocessor output
     string(REPLACE " " ";" COMMON_CXX_FLAGS_LIST ${COMMON_CXX_FLAGS})
     set(SINGLE_HEADER_OUTPUT ${CMAKE_CURRENT_LIST_DIR}/fixed_point.h)
-    set(FLAGS "-E" "-I${CMAKE_CURRENT_LIST_DIR}/../../include" "-std=c++11" "-DEXCEPTIONS=ON" "-DINT128=OFF")
+    set(FLAGS "-E" "-I${CMAKE_CURRENT_LIST_DIR}/../../include" "-std=c++11" "-DSG14_DISABLE_GCC_BUILTINS")
     add_custom_target(single_header
             ALL
             cat ${CMAKE_CURRENT_LIST_DIR}/header.h > ${SINGLE_HEADER_OUTPUT}

--- a/src/single_header/fixed_point.h
+++ b/src/single_header/fixed_point.h
@@ -19,6 +19,7 @@
 #include <stdexcept>
 #include <type_traits>
 
+       
 namespace sg14 {
     namespace _impl {
         template<class ... T>
@@ -361,12 +362,6 @@ namespace sg14 {
     constexpr int used_bits(Integer value)
     {
         return for_rep<int>(_numeric_impl::used_bits(), value);
-    }
-    constexpr int leading_bits(int value)
-    {
-        return (value>0)
-               ? __builtin_clz(value)-1
-               : digits<int>::value-used_bits(value);
     }
     template<class Integer>
     constexpr int leading_bits(const Integer& value)
@@ -2131,6 +2126,7 @@ namespace sg14 {
         return fixed_point<LhsRep, LhsExponent-RhsValue>::from_data(lhs.data());
     }
 }
+       
 namespace sg14 {
     namespace _impl {
         template<class Rep, int Exponent>


### PR DESCRIPTION
- allows header to be included with MSVC