### PR TITLE
MSVC warnings

### DIFF
--- a/include/sg14/auxiliary/elastic_integer.h
+++ b/include/sg14/auxiliary/elastic_integer.h
@@ -264,9 +264,7 @@ namespace sg14 {
                 const elastic_integer<LhsDigits, LhsNarrowest>& lhs,
                 const elastic_integer<RhsDigits, RhsNarrowest>& rhs,
                 Operator op)
-#if ! defined(_MSC_VER)
         -> decltype(op(cast_to_common_type(lhs, rhs), cast_to_common_type(rhs, lhs)))
-#endif
         {
             return op(cast_to_common_type(lhs, rhs), cast_to_common_type(rhs, lhs));
         }
@@ -371,9 +369,7 @@ namespace sg14 {
                 const elastic_integer<LhsDigits, LhsNarrowest>& lhs,
                 const elastic_integer<RhsDigits, RhsNarrowest>& rhs,
                 Operator op)
-#if ! defined(_MSC_VER)
         -> typename operate_params<Operator, LhsDigits, LhsNarrowest, RhsDigits, RhsNarrowest>::result_type
-#endif
         {
             using result_type = typename operate_params<Operator, LhsDigits, LhsNarrowest, RhsDigits, RhsNarrowest>::result_type;
             return result_type::from_data(
@@ -386,9 +382,7 @@ namespace sg14 {
     // unary operator-
     template<int RhsDigits, class RhsNarrowest>
     constexpr auto operator-(const elastic_integer<RhsDigits, RhsNarrowest>& rhs)
-#if ! defined(_MSC_VER)
     -> elastic_integer<RhsDigits, typename make_signed<RhsNarrowest>::type>
-#endif
     {
         using result_type = elastic_integer<RhsDigits, typename make_signed<RhsNarrowest>::type>;
         return result_type::from_data(-static_cast<result_type>(rhs).data());
@@ -397,9 +391,7 @@ namespace sg14 {
     // unary operator+
     template<int RhsDigits, class RhsNarrowest>
     constexpr auto operator+(const elastic_integer<RhsDigits, RhsNarrowest>& rhs)
-#if ! defined(_MSC_VER)
     -> elastic_integer<RhsDigits, typename make_signed<RhsNarrowest>::type>
-#endif
     {
         using result_type = elastic_integer<RhsDigits, typename make_signed<RhsNarrowest>::type>;
         return result_type::from_data(static_cast<result_type>(rhs).data());

--- a/include/sg14/bits/fixed_point_type.h
+++ b/include/sg14/bits/fixed_point_type.h
@@ -105,11 +105,7 @@ namespace sg14 {
 
     public:
         /// default constructor
-#if defined(_MSC_VER)
-        fixed_point() { }
-#else
         constexpr fixed_point() : _base() { }
-#endif
 
         /// constructor taking a fixed-point type
         template<class FromRep, int FromExponent>

--- a/include/sg14/bits/number_base.h
+++ b/include/sg14/bits/number_base.h
@@ -135,9 +135,7 @@ namespace sg14 {
         // unary operate
         template<class Operator, class RhsDerived, class RhsRep>
         constexpr auto operate(const number_base<RhsDerived, RhsRep>& rhs, Operator op)
-#if ! defined(_MSC_VER)
         -> decltype(op(rhs.data()))
-#endif
         {
             return op(rhs.data());
         }
@@ -186,9 +184,7 @@ namespace sg14 {
 
         template<class RhsDerived, class RhsRep>
         constexpr auto operator-(const number_base<RhsDerived, RhsRep>& rhs)
-#if ! defined(_MSC_VER)
         -> decltype(operate(rhs, minus_tag))
-#endif
         {
             return operate(rhs, minus_tag);
         }

--- a/src/common/common.cmake
+++ b/src/common/common.cmake
@@ -1,4 +1,4 @@
-if (POLICY CMP0054)
+﻿if (POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)
 endif()
 
@@ -8,7 +8,7 @@ include(ExternalProject)
 # build flags
 
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
-  set(MISC_FLAGS "/W4 /WX /wd4309 /errorReport:prompt /nologo")
+  set(MISC_FLAGS "/W4 /WX /errorReport:prompt /nologo")
 
   # no tested
   set(CPP17_ENABLED_FLAGS "/std:c++latest")

--- a/src/test/const_integer.cpp
+++ b/src/test/const_integer.cpp
@@ -48,7 +48,6 @@ namespace {
                 "sg14::const_integer construction test failed");
 
         // unary minus
-#if ! defined(_MSC_VER) || (_MSC_VER > 1900)
         static_assert(
                 identical(-const_integer<std::uint8_t, 1>{}, const_integer<int, -1>{}),
                 "sg14::const_integer unary minus test failed");
@@ -59,7 +58,6 @@ namespace {
         static_assert(
                 identical(-const_integer<unsigned, 1>{}, const_integer<unsigned, std::numeric_limits<unsigned>::max()>{}),
                 "sg14::const_integer unary minus test failed");
-#endif
 #endif
 
         // binary plus
@@ -96,10 +94,8 @@ namespace {
         static_assert(identical(0x91827364564738_c, const_integer<intmax_t, 0x91827364564738>()),
                       "sg14::literals test failed");
 
-#if ! defined(_MSC_VER) || (_MSC_VER > 1900)
         static_assert(
                 identical(-1_c, const_integer<intmax_t, -1>{}),
                 "sg14::const_integer addition test failed");
-#endif
     }
 }

--- a/src/test/elastic_fixed_point.cpp
+++ b/src/test/elastic_fixed_point.cpp
@@ -246,9 +246,7 @@ struct positive_elastic_test
 
     static_assert(is_equal_to(min*make_elastic_fixed_point(0_c), zero), "operator* test failed");
     static_assert(is_equal_to(min*make_elastic_fixed_point(1_c), min), "operator* test failed");
-#if ! defined(_MSC_VER)
     static_assert(is_equal_to(min*make_elastic_fixed_point(2_c), min+min), "operator* test failed");
-#endif
     static_assert(is_equal_to(min*make_elastic_fixed_point(3_c), min+min+min), "operator* test failed");
 
     static_assert(std::numeric_limits<decltype(zero*zero)>::is_signed
@@ -263,9 +261,7 @@ struct positive_elastic_test
     ////////////////////////////////////////////////////////////////////////////////
     // test operator/
 
-#if ! defined(_MSC_VER)
     static_assert(!is_less_than(min, min/make_elastic_fixed_point(2_c)), "operator/ test failed");
-#endif
     static_assert(is_equal_to(min/make_elastic_fixed_point(1_c), min), "operator/ test failed");
     static_assert(is_equal_to((min+min)/make_elastic_fixed_point(2_c), min), "operator/ test failed");
     static_assert(is_equal_to((min+min+min)/make_elastic_fixed_point(3_c), min), "operator/ test failed");
@@ -316,9 +312,7 @@ struct signed_elastic_test :
     // test numeric_limits<elastic_fixed_point>
 
     static_assert(is_less_than(negative_min, min), "numeric_limits test failed");
-#if ! defined(_MSC_VER)
     static_assert(is_equal_to(-max, lowest), "comparison test error");
-#endif
     //static_assert(is_equal_to(elastic_type{min+max+lowest}, elastic_type{1}), "comparison test error");
     static_assert(numeric_limits::is_signed, "numeric_limits test failed");
     static_assert(!numeric_limits::is_integer || elastic_type{-.5} != -.5, "numeric_limits test failed");

--- a/src/test/fixed_point_common.h
+++ b/src/test/fixed_point_common.h
@@ -963,7 +963,6 @@ struct FixedPointTesterOutsize {
     // simply assignment to and from underlying representation
     using numeric_limits = std::numeric_limits<fixed_point>;
     static constexpr fixed_point min = sg14::_impl::from_rep<fixed_point>(rep(1));
-#if !defined(_MSC_VER)
     static_assert(min.data() == rep(1), "all Rep types should be able to store the number 1!");
 
     // unary common_type_t
@@ -1005,7 +1004,6 @@ struct FixedPointTesterOutsize {
                     decltype(min - min),
                     ::fixed_point<decltype(declval<rep>() - declval<rep>()), exponent>>::value,
             "promotion rule for subtraction fixed_point<Rep> should match its Rep");
-#endif
 };
 
 // some tests cannot be performed at run-time because

--- a/src/test/make_elastic_fixed_point.cpp
+++ b/src/test/make_elastic_fixed_point.cpp
@@ -19,9 +19,7 @@ static constexpr auto int_digits = std::numeric_limits<int>::digits;
 
 static_assert(identical(make_elastic_fixed_point(const_integer<std::int64_t, -1>{}), sg14::elastic_fixed_point<1, 0, int>{-1}),
               "using too many bytes to represent -1");
-#if ! defined(_MSC_VER)
 static_assert(identical(make_elastic_fixed_point(-1_c), sg14::elastic_fixed_point<1, 0, int>{-1}), "using too many bits to represent -1");
-#endif
 
 static_assert(identical(make_elastic_fixed_point(123), elastic_fixed_point<int_digits>{123}), "sg14::make_elastic_fixed_point test failed");
 static_assert(
@@ -51,7 +49,6 @@ static_assert(sizeof(make_elastic_fixed_point(510_c)) == sizeof(int), "using too
 static_assert(sizeof(make_elastic_fixed_point(511_c)) == sizeof(int), "using too many bytes to represent 511");
 static_assert(sizeof(make_elastic_fixed_point(512_c)) == sizeof(int), "using too many bytes to represent 512");
 
-#if ! defined(_MSC_VER) || (_MSC_VER > 1900)
 static_assert(sizeof(make_elastic_fixed_point(-1_c)) == sizeof(int), "using too many bytes to represent -1");
 static_assert(sizeof(make_elastic_fixed_point(-127_c)) == sizeof(int), "using too many bytes to represent -127");
 static_assert(sizeof(make_elastic_fixed_point(-128_c)) == sizeof(int), "using too many bytes to represent -128");
@@ -59,7 +56,6 @@ static_assert(sizeof(make_elastic_fixed_point(-129_c)) == sizeof(int), "using to
 static_assert(sizeof(make_elastic_fixed_point(-254_c)) == sizeof(int), "using too many bytes to represent -254");
 static_assert(sizeof(make_elastic_fixed_point(-255_c)) == sizeof(int), "using too many bytes to represent -255");
 static_assert(sizeof(make_elastic_fixed_point(-256_c)) == sizeof(int), "using too many bytes to represent -256");
-#endif
 
 // ... but a more compact type can be chosen if size is the constraint
 static_assert(sizeof(make_elastic_fixed_point<signed char>(0_c)) == 1, "using too many bytes to represent 0");
@@ -71,7 +67,6 @@ static_assert(sizeof(make_elastic_fixed_point<signed char>(510_c)) == 2, "using 
 static_assert(sizeof(make_elastic_fixed_point<signed char>(511_c)) == 2, "using too many bytes to represent 511");
 static_assert(sizeof(make_elastic_fixed_point<signed char>(512_c)) == 1, "using too many bytes to represent 512");
 
-#if ! defined(_MSC_VER) || (_MSC_VER > 1900)
 static_assert(sizeof(make_elastic_fixed_point<signed char>(-1_c)) == 1, "using too many bytes to represent -1");
 static_assert(sizeof(make_elastic_fixed_point<signed char>(-127_c)) == 1, "using too many bytes to represent -127");
 static_assert(sizeof(make_elastic_fixed_point<signed char>(-128_c)) == 1, "using too many bytes to represent -128");
@@ -79,7 +74,6 @@ static_assert(sizeof(make_elastic_fixed_point<signed char>(-129_c)) == 2, "using
 static_assert(sizeof(make_elastic_fixed_point<signed char>(-254_c)) == 1, "using too many bytes to represent -254");
 static_assert(sizeof(make_elastic_fixed_point<signed char>(-255_c)) == 2, "using too many bytes to represent -255");
 static_assert(sizeof(make_elastic_fixed_point<signed char>(-256_c)) == 1, "using too many bytes to represent -256");
-#endif
 
 // some numbers are so big that you don't have the luxury of choosing
 static constexpr auto unsigned_limit = std::intmax_t{std::numeric_limits<unsigned>::max()} + 1;
@@ -121,9 +115,7 @@ struct make_elastic_test {
     static_assert(Value==0 || Value!=((Value/lsz1)*lsz1), "fractional_digits is too high");
 
     static_assert(std::numeric_limits<type>::is_signed, "signage doesn't match value");
-#if ! defined(_MSC_VER)
 //    static_assert(elastic_value==elastic_fixed_point<63, 0>{Value}, "make_elasticd value doesn't equal its source value");
-#endif
 };
 
 template

--- a/src/test/p0037.cpp
+++ b/src/test/p0037.cpp
@@ -126,13 +126,7 @@ TEST(proposal, examples)
             make_ufixed<4, 12>(1),
             make_ufixed<4, 12>(4),
             make_ufixed<4, 12>(9));
-#if defined(_MSC_VER)
-    constexpr auto expected = make_fixed<7, 24>{9.8994948864};
-    static_assert(std::is_same<decltype(m), decltype(expected)>::value, "Incorrect formation in proposal section, Examples");
-    ASSERT_EQ(expected, m);
-#else
     static_assert(identical(m, make_fixed<7, 24>{9.8994948864}), "Incorrect information in proposal section, Examples");
-#endif
 }
 
 TEST(proposal, zero)


### PR DESCRIPTION
removes lots of MS-specific code; addresses #58 